### PR TITLE
VZ-3368 Document Istio Upgrade Details

### DIFF
--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -146,15 +146,13 @@ weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0    
 ```
 
 ## Upgrade applications in the Istio service mesh
-If your upgrade includes a minor version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
+If your upgrade includes a minor version change to Istio, such as if you are upgrading from Verrazzano 1.0.x to 1.1.x, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
 Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
-
-If you are upgrading Verrazzano from version `1.0.X` to version `1.1.X`, then you are required to restart the application.
 
 ### Restarting applications
 If your application namespace has the `istio-injection=enabled` label, then your application components are in the Istio service mesh.
 As such, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
-For WebLogic applications, the WebLogic domain will undergo a hard restart. This will result in a brief WebLogic application downtime as the domain restarts.
+For WebLogic applications only, the WebLogic domain will undergo a hard restart. This will result in a brief WebLogic application downtime as the domain restarts.
 
 To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 When the annotation is added or the value is modified, Verrazzano will initiate a restart of all the application components.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -145,28 +145,28 @@ vmi-system-prometheus-0-7bf464d898-czq8r                 4/4     Running   0    
 weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0          27h
 ```
 
-## Upgrade Istio-managed applications
-If your upgrade includes a major version change to Istio, you must complete these additional the following actions to ensure that applications managed in the Istio mesh get upgraded properly.
+## Upgrade Istio managed applications
+If your upgrade includes a major version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
 Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
 
 ### Restarting applications
-If your application namespace has the `istio-injection=enabled` label, your application components are in the Istio service mesh.
-If your application is in the Istio service mesh, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
+If your application namespace has the `istio-injection=enabled` label, then your application components are in the Istio service mesh.
+As such, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
 Verrazzano cannot guarantee application persistence as the application components restart.
 For WebLogic applications specifically, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
 
-In order to trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
+To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.
 For example, you can annotate the Bob's Books example application by using the following command:
 
 ```shell
-kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3"
+$ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3"
 ```
 
-To verify that this example application configuration has been updated, this command should give the value of your annotation:
+To verify that this example application configuration has been updated, this command will return the value of your annotation:
 
 ```shell
-kubectl get appconfig bobs-books -n bobs-books -o jsonpath="{.metadata.annotations.verrazzano\.io/restart-version}"
+$ kubectl get appconfig bobs-books -n bobs-books -o jsonpath="{.metadata.annotations.verrazzano\.io/restart-version}"
 ```
 
 After completing the annotations and restarting, verify that your application is up and running as expected.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -162,7 +162,7 @@ Although the value of the annotation is insignificant to the upgrade, we recomme
 For example, you can annotate the Bob's Books example application by using the following command:
 
 ```shell
-$ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3" --overwrite
+$ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="1" --overwrite
 ```
 
 To verify that this example application configuration has been updated, this command will return the value of your annotation:

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -144,3 +144,29 @@ vmi-system-kibana-85565975b5-7hfdf                       2/2     Running   0    
 vmi-system-prometheus-0-7bf464d898-czq8r                 4/4     Running   0          27h
 weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0          27h
 ```
+
+## Upgrade Istio-managed applications
+If your upgrade includes a major version change to Istio, you must complete these additional the following actions to ensure that applications managed in the Istio mesh get upgraded properly.
+Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace have finished restarting.
+
+### Restarting applications
+If your application namespace has the `istio-injection=enabled` label, your application components are in the Istio service mesh.
+In this case, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
+Verrazzano cannot guarantee application persistence as the application components restart.
+For WebLogic applications specifically, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
+
+In order to trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
+Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.
+For example, you can annotate the bobs-books example application by using the following command:
+
+```shell
+kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3"
+```
+
+To verify that this example application configuration has been updated, this command should give the value of your annotation:
+
+```shell
+kubectl get appconfig bobs-books -n bobs-books -o 'jsonpath={.metadata.annotations.verrazzano\.io/restart-version}'
+```
+
+After completing the annotations and restarting, verify that your application is up and running as expected.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -160,6 +160,7 @@ As such, your application must be restarted to upgrade the Istio proxy sidecars 
 For WebLogic applications, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
 
 To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
+When the annotation is added or the value is modified, Verrazzano will initiate a restart of all the application components.
 Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.
 For example, you can annotate the Bob's Books example application by using the following command:
 

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -149,11 +149,15 @@ weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0    
 If your upgrade includes a minor version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
 Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
 
+Here is a list of all Verrazzano upgrades that contain minor version updates to Istio:
+| Old Release | New Release |
+| --- | --- |
+| 1.0.X | 1.1.X |
+
 ### Restarting applications
 If your application namespace has the `istio-injection=enabled` label, then your application components are in the Istio service mesh.
 As such, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
-Verrazzano cannot guarantee application persistence as the application components restart.
-For WebLogic applications specifically, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
+For WebLogic applications, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
 
 To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -145,8 +145,8 @@ vmi-system-prometheus-0-7bf464d898-czq8r                 4/4     Running   0    
 weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0          27h
 ```
 
-## Upgrade Istio managed applications
-If your upgrade includes a major version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
+## Upgrade applications in the Istio service mesh
+If your upgrade includes a minor version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
 Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
 
 ### Restarting applications

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -154,7 +154,7 @@ If you are upgrading Verrazzano from version `1.0.X` to version `1.1.X`, then yo
 ### Restarting applications
 If your application namespace has the `istio-injection=enabled` label, then your application components are in the Istio service mesh.
 As such, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
-For WebLogic applications, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
+For WebLogic applications, the WebLogic domain will undergo a hard restart. This will result in a brief WebLogic application downtime as the domain restarts.
 
 To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 When the annotation is added or the value is modified, Verrazzano will initiate a restart of all the application components.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -149,10 +149,7 @@ weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0    
 If your upgrade includes a minor version change to Istio, you must complete these additional actions to ensure that applications managed in the Istio mesh get upgraded properly.
 Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
 
-Here is a list of all Verrazzano upgrades that contain minor version updates to Istio:
-| Old Release | New Release |
-| --- | --- |
-| 1.0.X | 1.1.X |
+If you are upgrading Verrazzano from version `1.0.X` to version `1.1.X`, then you are required to restart the application.
 
 ### Restarting applications
 If your application namespace has the `istio-injection=enabled` label, then your application components are in the Istio service mesh.
@@ -161,11 +158,11 @@ For WebLogic applications, the WebLogic domain will undergo a hard restart. This
 
 To trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 When the annotation is added or the value is modified, Verrazzano will initiate a restart of all the application components.
-Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.
+Although the value of the annotation is insignificant to the upgrade, we recommend that you use whole number values to help keep track of your upgrades.
 For example, you can annotate the Bob's Books example application by using the following command:
 
 ```shell
-$ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3"
+$ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3" --overwrite
 ```
 
 To verify that this example application configuration has been updated, this command will return the value of your annotation:

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -147,17 +147,17 @@ weblogic-operator-7db5cdcf59-qxsr9                       1/1     Running   0    
 
 ## Upgrade Istio-managed applications
 If your upgrade includes a major version change to Istio, you must complete these additional the following actions to ensure that applications managed in the Istio mesh get upgraded properly.
-Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace have finished restarting.
+Before making any alterations to the application components, ensure that the Verrazzano Custom Resource status is `UpgradeComplete` and that all pods in the `verrazzano-system` namespace are in the `Running` state.
 
 ### Restarting applications
 If your application namespace has the `istio-injection=enabled` label, your application components are in the Istio service mesh.
-In this case, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
+If your application is in the Istio service mesh, your application must be restarted to upgrade the Istio proxy sidecars to the new version.
 Verrazzano cannot guarantee application persistence as the application components restart.
 For WebLogic applications specifically, the WebLogic domain will undergo a hard restart. This will result in WebLogic application downtime as the domains get restarted.
 
 In order to trigger this restart, you can annotate the application configuration with the key `verrazzano.io/restart-version`.
 Although the value of the annotation is insignificant to the upgrade, it is recommended to use whole number values to keep track of your upgrades.
-For example, you can annotate the bobs-books example application by using the following command:
+For example, you can annotate the Bob's Books example application by using the following command:
 
 ```shell
 kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-version="3"
@@ -166,7 +166,7 @@ kubectl annotate appconfig bobs-books -n bobs-books verrazzano.io/restart-versio
 To verify that this example application configuration has been updated, this command should give the value of your annotation:
 
 ```shell
-kubectl get appconfig bobs-books -n bobs-books -o 'jsonpath={.metadata.annotations.verrazzano\.io/restart-version}'
+kubectl get appconfig bobs-books -n bobs-books -o jsonpath="{.metadata.annotations.verrazzano\.io/restart-version}"
 ```
 
 After completing the annotations and restarting, verify that your application is up and running as expected.


### PR DESCRIPTION
This section is meant to inform users on how to restart applications to meet requirements of a major upgrade in Istio. This situation will occur when upgrading to the 1.1 release.