### PR TITLE
Backport Lift-Shift instructions for ToDo List application

### DIFF
--- a/content/en/docs/guides/lift-and-shift/mysql-oam.yaml
+++ b/content/en/docs/guides/lift-and-shift/mysql-oam.yaml
@@ -3,21 +3,6 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
-kind: ApplicationConfiguration
-metadata:
-  name: tododomain-mysql
-  namespace: tododomain
-  annotations:
-    version: v1.0.0
-    description: "tododomain mysql configuration"
-spec:
-  components:
-    # Added mysql components to the application topology
-    - componentName: todo-mysql-service
-    - componentName: todo-mysql-deployment
-    - componentName: todo-mysql-configmap
----
-apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
   name: todo-mysql-service
@@ -32,7 +17,7 @@ spec:
     spec:
       ports:
         - port: 3306
-          name: tls-mysql
+          name: mysql
       selector:
         app: mysql
       clusterIP: None

--- a/content/en/docs/guides/lift-and-shift/vz-application-modified.yaml
+++ b/content/en/docs/guides/lift-and-shift/vz-application-modified.yaml
@@ -28,6 +28,9 @@ spec:
                     - path: "/todo"
                       pathType: Prefix
     - componentName: tododomain-configmap
+    - componentName: todo-mysql-service
+    - componentName: todo-mysql-deployment
+    - componentName: todo-mysql-configmap
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component


### PR DESCRIPTION
Backporting the updated Lift-Shift instructions for the ToDo List application into release 1.0. 
- Fixes for - VZ-3431, VZ-3830, VZ-3831.
- Removed ApplicationConfiguration and tls prefix from MySQL Yaml.
- Updated vz-application-modified.yaml to include MySQL Verrazzano components.
- Updated Lift and shift instructions to do the necessary changes.