### PR TITLE
Updates for release 1.0.3

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,7 +1,7 @@
 # Verrazzano _default site params
 
 # The version number for the version of the product referenced by this doc set.
-release_version = "v1.0.2"
+release_version = "v1.0.3"
 
 copyright = "Oracle and/or its affiliates"
 #privacy_policy = "https://policies.google.com/privacy"

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -95,9 +95,10 @@ To install Verrazzano:
     The Verrazzano operator launches a Kubernetes [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) to install Verrazzano.  You can view the installation logs from that job with the following command:
 
     ```shell
-    $ kubectl logs -f \
+    $ kubectl logs -n verrazzano-install -f \
         $( \
           kubectl get pod \
+              -n verrazzano-install \
               -l job-name=verrazzano-install-example-verrazzano \
               -o jsonpath="{.items[0].metadata.name}" \
         )
@@ -202,9 +203,10 @@ To uninstall Verrazzano:
     The Verrazzano operator launches a Kubernetes [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) to delete the Verrazzano installation.  You can view the uninstall logs from that job with the following command:
 
     ```shell
-    $ kubectl logs -f \
+    $ kubectl logs -n verrazzano-install -f \
         $( \
           kubectl get pod \
+              -n verrazzano-install \
               -l job-name=verrazzano-uninstall-example-verrazzano \
               -o jsonpath="{.items[0].metadata.name}" \
         )

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -8,6 +8,7 @@ draft: false
 ### v1.0.3
 Fixes:
 - Fix to use load balancer service external IP address for application ingress when using an external load balancer and wildcard DNS.
+- Fixed scraping of Prometheus metrics for WebLogic workloads on managed clusters.
 - Rebuilt several component images to address known issues.
 - Updated to the following versions:
     - Grafana 6.7.4.

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,6 +5,15 @@ weight: 13
 draft: false
 ---
 
+### v1.0.3
+Fixes:
+- Fix to use load balancer service external IP for application ingress when using an external load balancer and wildcard DNS.
+- Rebuilt several component images to address known issues.
+- Updated to the following versions:
+    - Grafana 6.7.4.
+    - MySQL 8.0.27
+    - WebLogic Kubernetes Operator 3.3.3.
+
 ### v1.0.2
 Fixes:
 - Updated CoreDNS to version 1.6.2-1.

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -7,11 +7,10 @@ draft: false
 
 ### v1.0.3
 Fixes:
-- Fix to use load balancer service external IP for application ingress when using an external load balancer and wildcard DNS.
+- Fix to use load balancer service external IP address for application ingress when using an external load balancer and wildcard DNS.
 - Rebuilt several component images to address known issues.
 - Updated to the following versions:
     - Grafana 6.7.4.
-    - MySQL 8.0.27
     - WebLogic Kubernetes Operator 3.3.3.
 
 ### v1.0.2

--- a/content/en/docs/setup/install/installation.md
+++ b/content/en/docs/setup/install/installation.md
@@ -92,7 +92,7 @@ you want to install.
 
 To monitor the Console log output of the installation:
 ```shell
-$ kubectl -n verrazzano-install logs \
+$ kubectl logs -n verrazzano-install \
     -f $(kubectl get pod \
     -n verrazzano-install \
     -l job-name=verrazzano-install-my-verrazzano \

--- a/content/en/docs/setup/install/installation.md
+++ b/content/en/docs/setup/install/installation.md
@@ -94,6 +94,7 @@ To monitor the Console log output of the installation:
 ```shell
 $ kubectl -n verrazzano-install logs \
     -f $(kubectl get pod \
+    -n verrazzano-install \
     -l job-name=verrazzano-install-my-verrazzano \
     -o jsonpath="{.items[0].metadata.name}")
 ```

--- a/content/en/docs/setup/uninstall/uninstall.md
+++ b/content/en/docs/setup/uninstall/uninstall.md
@@ -19,8 +19,9 @@ $ MYVZ=$(kubectl  get vz -o jsonpath="{.items[0].metadata.name}")
 
 # Delete the Verrazzano custom resource
 $ kubectl delete verrazzano $MYVZ --wait=false
-$ kubectl logs \
+$ kubectl logs -n verrazzano-install \
     -f $(kubectl get pod \
+    -n verrazzano-install \
     -l job-name=verrazzano-uninstall-${MYVZ} \
     -o jsonpath="{.items[0].metadata.name}")
 ```

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -14,7 +14,7 @@ You can install Verrazzano on the following Kubernetes versions.
 
 | Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | Kubernetes Versions
 | ---        | ---          | ---                  | ---                       | ---
-| 1.0        | 2021-08-02   | 1.0.3                | 2021-11-??                | 1.18, 1.19, 1.20
+| 1.0        | 2021-08-02   | 1.0.3                | 2021-11-06                | 1.18, 1.19, 1.20
 
 For more information, see [Kubernetes Release Documentation](https://kubernetes.io/releases/).
 For platform specific details, see [Verrazzano platform setup]({{< relref "/docs/setup/platforms/_index.md" >}}).

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -47,7 +47,7 @@ component with its version and a brief description.
 | Istio | 1.7.3 | Service mesh that layers transparently onto existing distributed applications.
 | Keycloak | 10.0.2 | Provides single sign-on with Identity and Access Management.
 | Kibana | 7.6.1 | Provides search and data visualization capabilities for data indexed in Elasticsearch.
-| MySQL | 8.0.27 | Open source relational database management system used by Keycloak.
+| MySQL | 8.0.20 | Open source relational database management system used by Keycloak.
 | NGINX Ingress Controller | 0.46.0 | Traffic management solution for cloud‑native applications in Kubernetes.
 | Node Exporter | 1.0.0 | Prometheus exporter for hardware and OS metrics.
 | OAM Kubernetes Runtime | 0.3.0 | Plug-in for implementing Open Application Model (OAM) control plane with Kubernetes.

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -12,9 +12,9 @@ Verrazzano supports the following software versions.
 ### Kubernetes
 You can install Verrazzano on the following Kubernetes versions.
 
-| Verrazzano | Release Date | Patch Releases | Latest Patch Release Date | Kubernetes Versions
-| ---        | ---          | ---            | ---                       | ---                
-| 1.0        | 2021-08-02   | 1.0.2          | 2021-10-25                | 1.18, 1.19, 1.20
+| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | Kubernetes Versions
+| ---        | ---          | ---                  | ---                       | ---
+| 1.0        | 2021-08-02   | 1.0.3                | 2021-11-??                | 1.18, 1.19, 1.20
 
 For more information, see [Kubernetes Release Documentation](https://kubernetes.io/releases/).
 For platform specific details, see [Verrazzano platform setup]({{< relref "/docs/setup/platforms/_index.md" >}}).
@@ -43,14 +43,14 @@ component with its version and a brief description.
 | Elasticsearch | 7.6.1 | Provides a distributed, multitenant-capable full-text search engine.
 | ExternalDNS | 0.7.1 | Synchronizes exposed Kubernetes Services and ingresses with DNS providers.
 | Fluentd | 1.12.3 | Collects logs and sends them to Elasticsearch.
-| Grafana | 6.4.4 | Tool to help you study, analyze, and monitor metrics.
+| Grafana | 6.7.4 | Tool to help you study, analyze, and monitor metrics.
 | Istio | 1.7.3 | Service mesh that layers transparently onto existing distributed applications.
 | Keycloak | 10.0.2 | Provides single sign-on with Identity and Access Management.
 | Kibana | 7.6.1 | Provides search and data visualization capabilities for data indexed in Elasticsearch.
-| MySQL | 8.0.20 | Open source relational database management system used by Keycloak.
+| MySQL | 8.0.27 | Open source relational database management system used by Keycloak.
 | NGINX Ingress Controller | 0.46.0 | Traffic management solution for cloud‑native applications in Kubernetes.
 | Node Exporter | 1.0.0 | Prometheus exporter for hardware and OS metrics.
 | OAM Kubernetes Runtime | 0.3.0 | Plug-in for implementing Open Application Model (OAM) control plane with Kubernetes.
 | Prometheus | 2.13.1 | Provides event monitoring and alerting.
 | Rancher | 2.5.9 | Manages multiple Kubernetes clusters.
-| WebLogic Kubernetes Operator | 3.3.2 | Assists with deploying and managing WebLogic domains.
+| WebLogic Kubernetes Operator | 3.3.3 | Assists with deploying and managing WebLogic domains.


### PR DESCRIPTION
PR with updates for the 1.0.3 patch release and fixes to commands to include the verrazzano-install namespace.

**NOTE**: The patch release date in the versions.md file must be updated with the release date before this PR is merged.