### PR TITLE
Updates for release 1.0.3 (master)

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -95,9 +95,10 @@ To install Verrazzano:
     The Verrazzano operator launches a Kubernetes [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) to install Verrazzano.  You can view the installation logs from that job with the following command:
 
     ```shell
-    $ kubectl logs -f \
+    $ kubectl logs -n verrazzano-install -f \
         $( \
           kubectl get pod \
+              -n verrazzano-install \
               -l job-name=verrazzano-install-example-verrazzano \
               -o jsonpath="{.items[0].metadata.name}" \
         )
@@ -202,9 +203,10 @@ To uninstall Verrazzano:
     The Verrazzano operator launches a Kubernetes [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) to delete the Verrazzano installation.  You can view the uninstall logs from that job with the following command:
 
     ```shell
-    $ kubectl logs -f \
+    $ kubectl logs -n verrazzano-install -f \
         $( \
           kubectl get pod \
+              -n verrazzano-install \
               -l job-name=verrazzano-uninstall-example-verrazzano \
               -o jsonpath="{.items[0].metadata.name}" \
         )

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,6 +5,15 @@ weight: 13
 draft: false
 ---
 
+### v1.0.3
+Fixes:
+- Fix to use load balancer service external IP address for application ingress when using an external load balancer and wildcard DNS.
+- Fixed scraping of Prometheus metrics for WebLogic workloads on managed clusters.
+- Rebuilt several component images to address known issues.
+- Updated to the following versions:
+    - Grafana 6.7.4.
+    - WebLogic Kubernetes Operator 3.3.3.
+
 ### v1.0.2
 Fixes:
 - Updated CoreDNS to version 1.6.2-1.

--- a/content/en/docs/setup/install/installation.md
+++ b/content/en/docs/setup/install/installation.md
@@ -92,8 +92,9 @@ you want to install.
 
 To monitor the Console log output of the installation:
 ```shell
-$ kubectl -n verrazzano-install logs \
+$ kubectl logs -n verrazzano-install \
     -f $(kubectl get pod \
+    -n verrazzano-install \
     -l job-name=verrazzano-install-my-verrazzano \
     -o jsonpath="{.items[0].metadata.name}")
 ```

--- a/content/en/docs/setup/uninstall/uninstall.md
+++ b/content/en/docs/setup/uninstall/uninstall.md
@@ -19,8 +19,9 @@ $ MYVZ=$(kubectl  get vz -o jsonpath="{.items[0].metadata.name}")
 
 # Delete the Verrazzano custom resource
 $ kubectl delete verrazzano $MYVZ --wait=false
-$ kubectl logs \
+$ kubectl logs -n verrazzano-install \
     -f $(kubectl get pod \
+    -n verrazzano-install \
     -l job-name=verrazzano-uninstall-${MYVZ} \
     -o jsonpath="{.items[0].metadata.name}")
 ```

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -12,9 +12,9 @@ Verrazzano supports the following software versions.
 ### Kubernetes
 You can install Verrazzano on the following Kubernetes versions.
 
-| Verrazzano | Release Date | Patch Releases | Latest Patch Release Date | Kubernetes Versions
-| ---        | ---          | ---            | ---                       | ---                
-| 1.0        | 2021-08-02   | 1.0.1          | 2021-09-01                | 1.18, 1.19, 1.20   
+| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | Kubernetes Versions
+| ---        | ---          | ---                  | ---                       | ---
+| 1.0        | 2021-08-02   | 1.0.3                | 2021-11-06                | 1.18, 1.19, 1.20
 
 For more information, see [Kubernetes Release Documentation](https://kubernetes.io/releases/).
 For platform specific details, see [Verrazzano platform setup]({{< relref "/docs/setup/platforms/_index.md" >}}).

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -43,7 +43,7 @@ component with its version and a brief description.
 | Elasticsearch | 7.6.1 | Provides a distributed, multitenant-capable full-text search engine.
 | ExternalDNS | 0.7.1 | Synchronizes exposed Kubernetes Services and ingresses with DNS providers.
 | Fluentd | 1.12.3 | Collects logs and sends them to Elasticsearch.
-| Grafana | 6.4.4 | Tool to help you study, analyze, and monitor metrics.
+| Grafana | 6.7.4 | Tool to help you study, analyze, and monitor metrics.
 | Istio | 1.7.3 | Service mesh that layers transparently onto existing distributed applications.
 | Keycloak | 10.0.1 | Provides single sign-on with Identity and Access Management.
 | Kibana | 7.6.1 | Provides search and data visualization capabilities for data indexed in Elasticsearch.
@@ -53,4 +53,4 @@ component with its version and a brief description.
 | OAM Kubernetes Runtime | 0.3.0 | Plug-in for implementing Open Application Model (OAM) control plane with Kubernetes.
 | Prometheus | 2.13.1 | Provides event monitoring and alerting.
 | Rancher | 2.5.9 | Manages multiple Kubernetes clusters.
-| WebLogic Kubernetes Operator | 3.3.0 | Assists with deploying and managing WebLogic domains.
+| WebLogic Kubernetes Operator | 3.3.3 | Assists with deploying and managing WebLogic domains.


### PR DESCRIPTION
This is the port from the release-1.0 branch that includes updates for the 1.0.3 release as well as fixes to several commands that are missing `-n verrazzano-install`.

**Note** I did not update the release version references as those will get updated when version 1.1 is released.