### PR TITLE
VZ-3988: Build elasticsearch from source and clear of vulnerabilities.

### DIFF
--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,7 +5,7 @@ weight: 13
 draft: false
 ---
 
-### v1.1
+### v1.1.0
 Fixes:
 - Updated Elasticsearch to version 7.10.2
 

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -7,7 +7,7 @@ draft: false
 
 ### v1.1.0
 Fixes:
-- Updated Elasticsearch to version 7.10.2
+- Updated Elasticsearch to version 7.10.2.
 
 ### v1.0.3
 Fixes:

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -5,6 +5,10 @@ weight: 13
 draft: false
 ---
 
+### v1.1
+Fixes:
+- Updated Elasticsearch to version 7.10.2
+
 ### v1.0.3
 Fixes:
 - Fix to use load balancer service external IP address for application ingress when using an external load balancer and wildcard DNS.

--- a/content/en/docs/setup/versions.md
+++ b/content/en/docs/setup/versions.md
@@ -40,7 +40,7 @@ component with its version and a brief description.
 | ---       | ---     | ---         |
 | cert-manager | 1.2.0 | Automates the management and issuance of TLS certificates.
 | Coherence Operator | 3.2.1 | Assists with deploying and managing Coherence clusters.
-| Elasticsearch | 7.6.1 | Provides a distributed, multitenant-capable full-text search engine.
+| Elasticsearch | 7.10.2 | Provides a distributed, multitenant-capable full-text search engine.
 | ExternalDNS | 0.7.1 | Synchronizes exposed Kubernetes Services and ingresses with DNS providers.
 | Fluentd | 1.12.3 | Collects logs and sends them to Elasticsearch.
 | Grafana | 6.7.4 | Tool to help you study, analyze, and monitor metrics.


### PR DESCRIPTION
Updated the Elasticsearch version to 7.10.2 including a new release notes 1.1 section.