### PR TITLE
change kind capitalization

### DIFF
--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -199,7 +199,7 @@ Fixes:
 
 ### v0.9.0
 - Features:
-    - Added platform support for installing Verrazzano on Kind clusters.
+    - Added platform support for installing Verrazzano on kind clusters.
     - Log records are indexed from the OAM `appconfig` and `component` definitions using the following pattern: `namespace-appconfig-component`.
     - All system and curated components are now patchable.
     - More updates to Open Application Model (OAM) support.

--- a/content/en/docs/setup/install/multicluster.md
+++ b/content/en/docs/setup/install/multicluster.md
@@ -129,11 +129,11 @@ Create a Secret on the *admin* cluster that contains the CA certificate for the 
 1. Use the following instructions to obtain the Kubernetes API server address for the admin cluster. This address must
    be accessible from the managed cluster.
 
-   {{< tabs tabTotal="2" tabID="3" tabName1="Most Kubernetes Clusters" tabName2="Kind Clusters" >}}
+   {{< tabs tabTotal="2" tabID="3" tabName1="Most Kubernetes Clusters" tabName2="kind Clusters" >}}
    {{< tab tabNum="1" >}}
 <br>
 
-For most types of Kubernetes clusters, except for Kind clusters, you can find the externally accessible API server
+For most types of Kubernetes clusters, except for kind clusters, you can find the externally accessible API server
 address of the admin cluster from its `kubeconfig` file.
 
 ```
@@ -162,10 +162,10 @@ export ADMIN_K8S_SERVER_ADDRESS=<the server address from the config output>
    {{< tab tabNum="2" >}}
 <br>
 
-Kind clusters run within a Docker container. If your admin and managed clusters are Kind clusters, the API server
+kind clusters run within a Docker container. If your admin and managed clusters are kind clusters, the API server
 address of the admin cluster in its `kubeconfig` file is usually a local address on the host machine, which will not be
 accessible from the managed cluster. Use the `kind` command to obtain the "internal" `kubeconfig` of the admin
-cluster, which will contain a server address accessible from other Kind clusters on the same machine, and therefore in
+cluster, which will contain a server address accessible from other kind clusters on the same machine, and therefore in
 the same Docker network.
 
 ```

--- a/content/en/docs/setup/platforms/Generic/generic.md
+++ b/content/en/docs/setup/platforms/Generic/generic.md
@@ -17,7 +17,7 @@ Remember to not overlap network Classless Inter-Domain Routing (CIDR) blocks whe
 {{% /alert %}}
 
 You can install a load balancer, such as [MetalLB](https://metallb.universe.tf/). This setup requires knowledge of networking both
-inside and outside your Kubernetes cluster. This would include specifics of your [Container Network Interface](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) (CNI) implementation, IP address allocation schemes, and routing that go beyond the scope of this documentation. For a KIND implementation, see [Install and configure MetalLB]({{< relref "/docs/setup/platforms/kind/kind.md#install-and-configure-metallb" >}}).
+inside and outside your Kubernetes cluster. This would include specifics of your [Container Network Interface](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) (CNI) implementation, IP address allocation schemes, and routing that go beyond the scope of this documentation. For a kind implementation, see [Install and configure MetalLB]({{< relref "/docs/setup/platforms/kind/kind.md#install-and-configure-metallb" >}}).
 
 
 It is possible to use a Kubernetes [Service of type NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) to test aspects of Verrazzano.

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -1,40 +1,40 @@
 ---
-title: KIND
-description: Instructions for setting up a KIND cluster for Verrazzano
-linkTitle: KIND
+title: kind
+description: Instructions for setting up a kind cluster for Verrazzano
+linkTitle: kind
 Weight: 8
 draft: false
 ---
 
-[KIND](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker container “nodes”.  Follow
-these instructions to prepare a KIND cluster for running Verrazzano.
+[kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker container “nodes”.  Follow
+these instructions to prepare a kind cluster for running Verrazzano.
 
 {{% alert title="NOTE" color="warning" %}}
-KIND is not recommended for use on macOS and Windows because the Docker network is not directly exposed
+kind is not recommended for use on macOS and Windows because the Docker network is not directly exposed
 to the host.
 {{% /alert %}}
 
 ## Prerequisites
 
 - Install [Docker](https://docs.docker.com/install/)
-- Install [KIND](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 
-## Prepare the KIND cluster
+## Prepare the kind cluster
 
-To prepare the KIND cluster for use with Verrazzano, you must create the cluster and then install and configure
+To prepare the kind cluster for use with Verrazzano, you must create the cluster and then install and configure
 [MetalLB](https://metallb.universe.tf/) in that cluster.
 
-You can create the KIND cluster in two ways: with or without image caching; image caching can speed up your
+You can create the kind cluster in two ways: with or without image caching; image caching can speed up your
 installation time.
 
-### Create a KIND cluster
+### Create a kind cluster
 
-KIND images are prebuilt for each release.  To find images suitable for a given release, check the
-[release notes](https://github.com/kubernetes-sigs/kind/releases) for your KIND version (check with `kind version`).
-There you'll find a complete listing of images created for a KIND release.
+kind images are prebuilt for each release.  To find images suitable for a given release, check the
+[release notes](https://github.com/kubernetes-sigs/kind/releases) for your kind version (check with `kind version`).
+There you'll find a complete listing of images created for a kind release.
 
-The following example references a Kubernetes v1.18.8-based image built for KIND v0.9.0.  Replace that image
-with one suitable for the KIND release you are using.
+The following example references a Kubernetes v1.18.8-based image built for kind v0.9.0.  Replace that image
+with one suitable for the kind release you are using.
 
 ```
 $ kind create cluster --config - <<EOF
@@ -53,11 +53,11 @@ nodes:
 EOF
 ```
 
-### Create a KIND cluster with image caching
+### Create a kind cluster with image caching
 
-While developing or experimenting with Verrazzano, you might destroy and re-create your KIND cluster multiple
+While developing or experimenting with Verrazzano, you might destroy and re-create your kind cluster multiple
 times.  To speed up Verrazzano installation, follow these steps to ensure that the image cache used by
-containerd inside a KIND cluster, is preserved across clusters. Subsequent installations will be faster
+containerd inside a kind cluster, is preserved across clusters. Subsequent installations will be faster
 because they will not need to pull the images again.
 
 1\. Create a named Docker volume that will be used for the image cache, and note its `Mountpoint` path. In this example, the volume is named `containerd`.
@@ -78,7 +78,7 @@ $ docker volume inspect containerd #Sample output is shown
 }
 ```
 
-2\. Specify the `Mountpoint` path obtained, as the `hostPath` under `extraMounts` in your KIND configuration file, with a `containerPath` of `/var/lib/containerd`, which is the default containerd image caching location inside the KIND container. An example of the modified KIND configuration is shown in the following `create cluster` command:
+2\. Specify the `Mountpoint` path obtained, as the `hostPath` under `extraMounts` in your kind configuration file, with a `containerPath` of `/var/lib/containerd`, which is the default containerd image caching location inside the kind container. An example of the modified kind configuration is shown in the following `create cluster` command:
 
 ```
 $ kind create cluster --config - <<EOF
@@ -96,13 +96,13 @@ nodes:
             "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
     extraMounts:
       - hostPath: /var/lib/docker/volumes/containerd/_data
-        containerPath: /var/lib/containerd #This is the location of the image cache inside the KIND container
+        containerPath: /var/lib/containerd #This is the location of the image cache inside the kind container
 EOF
 ```
 
 ## Install and configure MetalLB
 
-By default, KIND does not provide an implementation of network load balancers ([Services of type LoadBalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)).
+By default, kind does not provide an implementation of network load balancers ([Services of type LoadBalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)).
 [MetalLB](https://metallb.universe.tf/) offers a network load balancer implementation.
 
 To install MetalLB:
@@ -118,16 +118,16 @@ $ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/mani
 For further details, see the MetalLB [installation guide](https://metallb.universe.tf/installation/#installation-by-manifest).
 
 MetalLB is idle until configured.  Configure MetalLB in Layer 2 mode and give it control over a range of IP addresses in the `kind` Docker network.
-In versions v0.7.0 and earlier, KIND uses Docker's default bridge network; in versions v0.8.0 and later, it creates its own bridge network in KIND.
+In versions v0.7.0 and earlier, kind uses Docker's default bridge network; in versions v0.8.0 and later, it creates its own bridge network in kind.
 
-To determine the subnet of the `kind` Docker network in KIND v0.8.0 and later:
+To determine the subnet of the `kind` Docker network in kind v0.8.0 and later:
 
 ```
 $ docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r
 172.18.0.0/16
 ```
 
-To determine the subnet of the `kind` Docker network in KIND v0.7.0 and earlier:
+To determine the subnet of the `kind` Docker network in kind v0.7.0 and earlier:
 
 ```
 $ docker inspect bridge | jq '.[0].IPAM.Config[0].Subnet' -r


### PR DESCRIPTION
After discussion with Style Guide experts, decided to use lowercase kind (tool name) and command, `kind`.