### PR TITLE
VZ-4959 add namespace to quickstart instructions for hello-helidon

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -103,7 +103,7 @@ To install Verrazzano:
         -n verrazzano-install \
         -l app=verrazzano-platform-operator \
         -o jsonpath="{.items[0].metadata.name}") | grep '^{.*}$' \
-        | jq -r '."@timestamp" as $timestamp | "\($timestamp) \(.level) \(.message)"' 
+        | jq -r '."@timestamp" as $timestamp | "\($timestamp) \(.level) \(.message)"'
     ```
 
 ## Deploy an example application
@@ -127,8 +127,8 @@ enabled for Istio.
 1. Apply the `hello-helidon` resources to deploy the application.
 
    ```
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}}
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}}
+   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}} -n hello-helidon
+   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}} -n hello-helidon
    ```
 
 1. Wait for the application to be ready.


### PR DESCRIPTION
quick start guide instructions for hello-helidon was missing namespace on the apply, it was correct in the samples doc for hello-helidon, but it would not work correctly if a customer just used the instructions directly presented in the quick start guide.