### PR TITLE
backport-fix-url

### DIFF
--- a/content/en/docs/samples/helidon-config/_index.md
+++ b/content/en/docs/samples/helidon-config/_index.md
@@ -98,45 +98,9 @@ Follow these steps to test the endpoints:
        before deploying the `helidon-config` application.
      * Then, you can use a browser to access the application at `https://<yourhost.your.domain>/config`.
 
-1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.  
+1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such. You
+can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).   
 
-     Accessing them may require the following:
-
-    - Run this command to get the password that was generated for the telemetry components:
-
-      ```
-      $ kubectl get secret \
-         --namespace verrazzano-system verrazzano \
-         -o jsonpath={.data.password} | base64 \
-         --decode; echo
-      ```
-      The associated user name is `verrazzano`.
-
-    - You will have to accept the certificates associated with the endpoints.
-
-      You can retrieve the list of available ingresses with following command:
-
-         ```
-         $ kubectl get ingress -n verrazzano-system
-
-         # Sample output
-         NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-         verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-         vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-         vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-         vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-         vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-         vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-         ```  
-
-         Using the ingress host information, some of the endpoints available are:
-
-         | Description| Address | Credentials |
-         | --- | --- | --- |
-         | Kibana | `https://[vmi-system-kibana ingress host]` | `verrazzano`/`telemetry-password` |
-         | Grafana | `https://[vmi-system-grafana ingress host]` | `verrazzano`/`telemetry-password` |
-         | Prometheus | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |    
-         | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
 
 ## Troubleshooting
 

--- a/content/en/docs/samples/hello-helidon/_index.md
+++ b/content/en/docs/samples/hello-helidon/_index.md
@@ -99,45 +99,8 @@ Follow these steps to test the endpoints:
        before deploying the `hello-helidon` application.
      * Then, you can use a browser to access the application at `https://<yourhost.your.domain>/greet`.     
 
-1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.  
-
-     Accessing them may require the following:
-
-    - Run this command to get the password that was generated for the telemetry components:
-
-      ```
-      $ kubectl get secret \
-         --namespace verrazzano-system verrazzano \
-         -o jsonpath={.data.password} | base64 \
-         --decode; echo
-      ```
-      The associated user name is `verrazzano`.
-
-    - You will have to accept the certificates associated with the endpoints.
-
-      You can retrieve the list of available ingresses with following command:
-
-         ```
-         $ kubectl get ingress -n verrazzano-system
-
-         # Sample output
-         NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-         verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-         vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-         vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-         vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-         vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-         vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-         ```  
-
-         Using the ingress host information, some of the endpoints available are:
-
-         | Description| Address | Credentials |
-         | --- | --- | --- |
-         | Kibana | `https://[vmi-system-kibana ingress host]` | `verrazzano`/`telemetry-password` |
-         | Grafana | `https://[vmi-system-grafana ingress host]` | `verrazzano`/`telemetry-password` |
-         | Prometheus | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |    
-         | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
+1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.
+You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).  
 
 
 ## Troubleshooting

--- a/content/en/docs/samples/multicluster/sock-shop/_index.md
+++ b/content/en/docs/samples/multicluster/sock-shop/_index.md
@@ -175,33 +175,7 @@ Follow these steps to test the endpoints:
     users-coh-0      2/2     Running   0          38m
    ```
 1. A variety of endpoints are available to further explore the logs, metrics, and such, associated with
-the deployed Sock Shop application.  Accessing them may require the following:
-
-    - Run this command to get the password that was generated for the telemetry components:
-        ```
-        $ kubectl --kubeconfig $KUBECONFIG_ADMIN get secret \
-            --namespace verrazzano-system verrazzano \
-            -o jsonpath={.data.password} | base64 \
-            --decode; echo
-        ```
-        The associated user name is `verrazzano`.
-
-    - You will have to accept the certificates associated with the endpoints.
-
-    You can retrieve the list of available ingresses with following command:
-
-    ```
-    $ kubectl --kubeconfig $KUBECONFIG_MANAGED1 get ingress -n verrazzano-system
-    NAME                    CLASS    HOSTS                                              ADDRESS       PORTS     AGE
-    verrazzano-ingress      <none>   verrazzano.default.10.11.12.13.nip.io              10.11.12.13   80, 443   32m
-    vmi-system-prometheus   <none>   prometheus.vmi.system.default.10.11.12.13.nip.io   10.11.12.13   80, 443   32m
-     ```  
-
-    Using the ingress host information, some of the endpoints available are:
-
-    | Description| Address | Credentials |
-    | --- | --- | --- |
-    | Prometheus | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |    
+the deployed Sock Shop application.  You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).
 
 ## Undeploy the Sock Shop application
 

--- a/content/en/docs/samples/multicluster/todo-list/_index.md
+++ b/content/en/docs/samples/multicluster/todo-list/_index.md
@@ -141,41 +141,7 @@ $ export KUBECONFIG_MANAGED1=/path/to/your/managedclusterkubeconfig
 
 1. A variety of endpoints associated with
    the deployed ToDo List application, are available to further explore the logs, metrics, and such.
-   Accessing them may require the following:
-
-   * Run this command to get the password that was generated for the telemetry components:
-     ```
-     $ kubectl --kubeconfig $KUBECONFIG_ADMIN get secret \
-         --namespace verrazzano-system verrazzano -o jsonpath={.data.password} | base64 \
-         --decode; echo
-     ```
-     The associated user name is `verrazzano`.
-
-   * You will have to accept the certificates associated with the endpoints.
-
-   You can retrieve the list of available ingresses with following command:
-
-   ```
-   $ kubectl --kubeconfig $KUBECONFIG_ADMIN get ingress -n verrazzano-system
-
-   # Sample output
-   NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-   verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-   vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-   vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-   vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-   vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-   vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-   ```
-
-   Using the ingress host information, some of the endpoints available are:
-
-   | Description | Address | Credentials |
-   | ----------- | ------- | ----------- |
-   | Kibana      | `https://[vmi-system-kibana ingress host]`     | `verrazzano`/`telemetry-password` |
-   | Grafana     | `https://[vmi-system-grafana ingress host]`    | `verrazzano`/`telemetry-password` |
-   | Prometheus  | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |
-   | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
+   You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).
 
 ## Troubleshooting
 

--- a/content/en/docs/samples/sock-shop.md
+++ b/content/en/docs/samples/sock-shop.md
@@ -170,45 +170,8 @@ Follow these steps to test the endpoints:
        before deploying the Sock Shop application.
      * Then, you can use a browser to access the application at `https://<yourhost.your.domain>/catalogue`.
 
-1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.  
-
-     Accessing them may require the following:
-
-    - Run this command to get the password that was generated for the telemetry components:
-      ```
-      $ kubectl get secret \
-         --namespace verrazzano-system verrazzano \
-         -o jsonpath={.data.password} | base64 \
-         --decode; echo
-      ```
-      The associated user name is `verrazzano`.
-
-    - You will have to accept the certificates associated with the endpoints.
-
-      You can retrieve the list of available ingresses with following command:
-
-        ```
-         $ kubectl get ingress -n verrazzano-system
-
-         # Sample output
-         NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-         verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-         vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-         vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-         vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-         vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-         vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-        ```  
-
-        Using the ingress host information, some of the endpoints available are:
-
-        | Description| Address | Credentials |
-        | --- | --- | --- |
-        | Kibana | `https://[vmi-system-kibana ingress host]` | `verrazzano`/`telemetry-password` |
-        | Grafana | `https://[vmi-system-grafana ingress host]` | `verrazzano`/`telemetry-password` |
-        | Prometheus | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |    
-        | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
-
+1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.
+You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).
 
 ## Troubleshooting
 

--- a/content/en/docs/samples/spring-boot.md
+++ b/content/en/docs/samples/spring-boot.md
@@ -100,44 +100,7 @@ This example provides a simple web application developed using [Spring Boot](htt
        The actuator endpoint is accessible under the path `/actuator` and the Prometheus endpoint exposing metrics data in a format that can be scraped by a Prometheus server is accessible under the path `/actuator/prometheus`.
 
 1. A variety of endpoints associated with the deployed application, are available to further explore the logs, metrics, and such.
-
-   Accessing them may require the following:
-
-   * Run this command to get the password that was generated for the telemetry components:
-     ```
-     $ kubectl get secret \
-        --namespace verrazzano-system verrazzano \
-        -o jsonpath={.data.password} | base64 \
-        --decode; echo
-     ```
-     The associated user name is `verrazzano`.
-
-   * You will have to accept the certificates associated with the endpoints.
-
-   You can retrieve the list of available ingresses with following command:
-
-   ```
-   $ kubectl get ingress -n verrazzano-system
-
-   # Sample output
-   NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-   verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-   vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-   vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-   vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-   vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-   vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-    ```
-
-   Using the ingress host information, some of the endpoints available are:
-
-   | Description | Address | Credentials |
-   | ----------- | ------- | ----------- |
-   | Kibana      | `https://[vmi-system-kibana ingress host]`     | `verrazzano`/`telemetry-password` |
-   | Grafana     | `https://[vmi-system-grafana ingress host]`    | `verrazzano`/`telemetry-password` |
-   | Prometheus  | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |
-   | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
-
+You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).
 
 ## Undeploy the application   
 

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -10,7 +10,7 @@ description: "An example application containing a WebLogic component"
 * To download the example image, you must first accept the license agreement.
   * In a browser, navigate to https://container-registry.oracle.com/ and sign in.
   * Search for `example-todo` and `weblogic`.
-  * For each one: 
+  * For each one:
      * Select the image name in the results.
      * From the drop-down menu, select your language and click Continue.
      * Then read and accept the license agreement.
@@ -140,42 +140,7 @@ you can use the `kubectl wait` command. You may need to repeat the `kubectl wait
        with an edit field and an **Add** button that lets you add tasks.
 
 1. A variety of endpoints associated with the deployed ToDo List application, are available to further explore the logs, metrics, and such.
-   Accessing them may require the following:
-
-   * Run this command to get the password that was generated for the telemetry components:
-     ```
-     $ kubectl get secret \
-         --namespace verrazzano-system verrazzano \
-         -o jsonpath='{.data.password}' | base64 \
-         --decode; echo
-     ```
-     The associated user name is `verrazzano`.
-
-   * You will have to accept the certificates associated with the endpoints.
-
-   You can retrieve the list of available ingresses with following command:
-
-   ```
-   $ kubectl get ingress -n verrazzano-system
-
-   # Sample output
-   NAME                    CLASS    HOSTS                                                 ADDRESS       PORTS     AGE
-   verrazzano-ingress      <none>   verrazzano.default.11.22.33.44.nip.io                 11.22.33.44   80, 443   7d
-   vmi-system-es-ingest    <none>   elasticsearch.vmi.system.default.11.22.33.44.nip.io   11.22.33.44   80, 443   7d
-   vmi-system-grafana      <none>   grafana.vmi.system.default.11.22.33.44.nip.io         11.22.33.44   80, 443   7d
-   vmi-system-kiali        <none>   kiali.vmi.system.default.11.22.33.44.nip.io           11.22.33.44   80, 443   7d
-   vmi-system-kibana       <none>   kibana.vmi.system.default.11.22.33.44.nip.io          11.22.33.44   80, 443   7d
-   vmi-system-prometheus   <none>   prometheus.vmi.system.default.11.22.33.44.nip.io      11.22.33.44   80, 443   7d
-   ```
-
-   Using the ingress host information, some of the endpoints available are:
-
-   | Description | Address | Credentials |
-   | ----------- | ------- | ----------- |
-   | Kibana      | `https://[vmi-system-kibana ingress host]`     | `verrazzano`/`telemetry-password` |
-   | Grafana     | `https://[vmi-system-grafana ingress host]`    | `verrazzano`/`telemetry-password` |
-   | Prometheus  | `https://[vmi-system-prometheus ingress host]` | `verrazzano`/`telemetry-password` |
-   | Kiali | `https://[vmi-system-kiali ingress host]` | `verrazzano`/`telemetry-password` |
+   You can access them according to the directions [here]({{< relref "/docs/operations/#get-the-consoles-urls" >}}).
 
 ## Access the WebLogic Server Administration Console
 


### PR DESCRIPTION
Backport Fix to Remove References to Variety of URLs in Example Docs to the 1.1 docs