### PR TITLE
remove newlines from command

### DIFF
--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -147,10 +147,7 @@ example-verrazzano   UpgradeFailed   v1.1.1
 ```
 You can restart the upgrade by setting the annotation `verrazzano.io/upgrade-retry-version` to any unique value.  For example:
 ```
-$ kubectl patch vz example-verrazzano -p '{"metadata":{"annotations":
-{"verrazzano.io/upgrade-retry-version":"v1.1.2-1"}
-
-}}' --type=merge
+$ kubectl patch vz example-verrazzano -p '{"metadata":{"annotations": {"verrazzano.io/upgrade-retry-version":"v1.1.2-1"} }}' --type=merge
 ```
 
 ## Verify the upgrade


### PR DESCRIPTION
Remove the newlines from the restart the upgrade command in the 1.1 Upgrade docs.