### PR TITLE
VZ-5031: Update dev profile to use persistent storage by default

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -82,6 +82,16 @@ To install Verrazzano:
       name: example-verrazzano
     spec:
       profile: dev
+      defaultVolumeSource:
+        persistentVolumeClaim:
+          claimName: dev-storage
+      volumeClaimSpecTemplates:
+        - metadata:
+            name: dev-storage
+          spec:
+            resources:
+              requests:
+                storage: 2Gi
     EOF
     ```
 

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -84,10 +84,10 @@ To install Verrazzano:
       profile: dev
       defaultVolumeSource:
         persistentVolumeClaim:
-          claimName: dev-storage
+          claimName: verrazzano-storage
       volumeClaimSpecTemplates:
         - metadata:
-            name: dev-storage
+            name: verrazzano-storage
           spec:
             resources:
               requests:


### PR DESCRIPTION
Change the quick start VZ CR to use persistence.  This is a temporary way to prevent issues related to upgrade of Verrazzano installations without persistence.  This can be back ported to the 1.1 and 1.2 code lines.