### PR TITLE
VZ-6184 Update to Multicluster Troubleshooting documentation

### DIFF
--- a/content/en/docs/troubleshooting/troubleshooting-multicluster.md
+++ b/content/en/docs/troubleshooting/troubleshooting-multicluster.md
@@ -16,10 +16,10 @@ use the following steps to troubleshoot:
 - Check the multicluster resource's status field on the admin cluster to know what the status of that resource is
   on each managed cluster to which it is targeted.
 
-If you update [DNS]({{< relref "/docs/setup/customizing/dns" >}}) of the admin cluster and notice that the
-managed cluster status is unavailable in the Rancher console along with the error `x509: certificate is valid for
-<rancher new url>, not <rancher old url>` seen in the cattle-cluster-agent (Rancher Agent) logs on the
-managed cluster, then re-register the managed cluster as mentioned [here](#re-register-the-managed-cluster).
+If you update the [DNS]({{< relref "/docs/setup/customizing/dns" >}}) of the admin cluster and notice that the
+managed cluster status is unavailable in the Rancher console, along with the error `x509: certificate is valid for
+<rancher new url>, not <rancher old url>` seen in the `cattle-cluster-agent` (Rancher Agent) logs on the
+managed cluster, then re-register the managed cluster, as described [here](#re-register-the-managed-cluster).
 
 ## Verify managed cluster registration and connectivity
 You can verify that a managed cluster was successfully registered with an admin cluster by viewing the
@@ -131,10 +131,10 @@ output:
 The status message contains additional information on the operation's success or failure.
 
 ## Re-register the managed cluster
-Perform the below steps to re-register the managed cluster with the admin cluster. The cluster against which to run the
-command is indicated in each code block.
-#### On the admin cluster
-Export the register YAML file created on the admin cluster freshly to re-register the managed cluster.
+Perform the following steps to re-register the managed cluster with the admin cluster. The cluster against which to run
+the command is indicated in each code block.
+1. On the admin cluster, export the register YAML file newly created on the admin cluster to re-register the 
+   managed cluster.
    ```
    # On the admin cluster
    $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \
@@ -142,8 +142,7 @@ Export the register YAML file created on the admin cluster freshly to re-registe
        -n verrazzano-mc \
        -o jsonpath={.data.yaml} | base64 --decode > register_new.yaml
    ```
-#### On the managed cluster
-Apply the registration file exported in the previous step, on the managed cluster.
+2. On the managed cluster, apply the registration file exported in the previous step, on the managed cluster.
    ```
    # On the managed cluster
    $ kubectl --kubeconfig $KUBECONFIG_MANAGED1 --context $KUBECONTEXT_MANAGED1 \
@@ -152,9 +151,8 @@ Apply the registration file exported in the previous step, on the managed cluste
    # Once the command succeeds, you may delete the register_new.yaml file
    $ rm register_new.yaml
    ```
-#### On the admin cluster
-Run `kubectl patch clusters.management.cattle.io` on the admin cluster to trigger redeployment of the Rancher agent 
-on the managed cluster.
+3. On the admin cluster, run `kubectl patch clusters.management.cattle.io` on the admin cluster to trigger redeployment
+   of the Rancher agent on the managed cluster.
    ```
    # On the admin cluster
    $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \

--- a/content/en/docs/troubleshooting/troubleshooting-multicluster.md
+++ b/content/en/docs/troubleshooting/troubleshooting-multicluster.md
@@ -142,7 +142,7 @@ the command is indicated in each code block.
        -n verrazzano-mc \
        -o jsonpath={.data.yaml} | base64 --decode > register_new.yaml
    ```
-2. On the managed cluster, apply the registration file exported in the previous step, on the managed cluster.
+2. On the managed cluster, apply the registration file exported in the previous step.
    ```
    # On the managed cluster
    $ kubectl --kubeconfig $KUBECONFIG_MANAGED1 --context $KUBECONTEXT_MANAGED1 \
@@ -151,8 +151,8 @@ the command is indicated in each code block.
    # Once the command succeeds, you may delete the register_new.yaml file
    $ rm register_new.yaml
    ```
-3. On the admin cluster, run `kubectl patch clusters.management.cattle.io` on the admin cluster to trigger redeployment
-   of the Rancher agent on the managed cluster.
+3. On the admin cluster, run `kubectl patch clusters.management.cattle.io` to trigger redeployment of the Rancher agent
+   on the managed cluster.
    ```
    # On the admin cluster
    $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \

--- a/content/en/docs/troubleshooting/troubleshooting-multicluster.md
+++ b/content/en/docs/troubleshooting/troubleshooting-multicluster.md
@@ -16,6 +16,11 @@ use the following steps to troubleshoot:
 - Check the multicluster resource's status field on the admin cluster to know what the status of that resource is
   on each managed cluster to which it is targeted.
 
+If you update [DNS]({{< relref "/docs/setup/customizing/dns" >}}) of the admin cluster and notice that the
+managed cluster status is unavailable in the Rancher console along with the error `x509: certificate is valid for
+<rancher new url>, not <rancher old url>` seen in the cattle-cluster-agent (Rancher Agent) logs on the
+managed cluster, then re-register the managed cluster as mentioned [here](#re-register-the-managed-cluster).
+
 ## Verify managed cluster registration and connectivity
 You can verify that a managed cluster was successfully registered with an admin cluster by viewing the
 corresponding VerrazzanoManagedCluster (VMC) resource on the admin cluster. For example, to verify that a managed cluster
@@ -124,3 +129,46 @@ output:
 ```
 
 The status message contains additional information on the operation's success or failure.
+
+## Re-register the managed cluster
+Perform the below steps to re-register the managed cluster with the admin cluster. The cluster against which to run the
+command is indicated in each code block.
+#### On the admin cluster
+Export the register YAML file created on the admin cluster freshly to re-register the managed cluster.
+   ```
+   # On the admin cluster
+   $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \
+       get secret verrazzano-cluster-managed1-manifest \
+       -n verrazzano-mc \
+       -o jsonpath={.data.yaml} | base64 --decode > register_new.yaml
+   ```
+#### On the managed cluster
+Apply the registration file exported in the previous step, on the managed cluster.
+   ```
+   # On the managed cluster
+   $ kubectl --kubeconfig $KUBECONFIG_MANAGED1 --context $KUBECONTEXT_MANAGED1 \
+       apply -f register_new.yaml
+
+   # Once the command succeeds, you may delete the register_new.yaml file
+   $ rm register_new.yaml
+   ```
+#### On the admin cluster
+Run `kubectl patch clusters.management.cattle.io` on the admin cluster to trigger redeployment of the Rancher agent 
+on the managed cluster.
+   ```
+   # On the admin cluster
+   $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \
+       get clusters.management.cattle.io
+
+   # Sample output
+   NAME      AGE
+   c-mzb2h   4h48m
+   local     4h56m
+ 
+   $ kubectl --kubeconfig $KUBECONFIG_ADMIN --context $KUBECONTEXT_ADMIN \ 
+       patch clusters.management.cattle.io <the managed cluster name from the above output> \
+       -p '{"status":{"agentImage":"dummy"}}' --type merge
+
+   # Sample output
+   cluster.management.cattle.io/c-mzb2h patched
+   ```


### PR DESCRIPTION
Updated the multicluster troubleshooting section to re-register the managed cluster in case of the DNS changes on the admin cluster leading to managed cluster status unavailable in the Rancher console.