### PR TITLE
Release 1.3.1 RN backport

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -2,13 +2,13 @@
 
 # The version number for the version of the product referenced by this doc set.
 # Used by short codes release_asset_url and release_source_url which are defined files in layouts/shortcodes
-release_version = "v1.3.0"
+release_version = "v1.3.1"
 
 # Version number used as part of search result when downloading from Oracle Software Delivery Cloud
-download_package_version = "1.3"
+download_package_version = "1.3.1"
 
 # Full version number used as part of downloaded artifact when downloading from Oracle Software Delivery Cloud
-download_package_full_version = "1.3.0"
+download_package_full_version = "1.3.1"
 
 opensearch_docs_url = "https://opensearch.org/docs/1.2"
 
@@ -27,7 +27,7 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the 
 # current doc set.
-version = "v1.3.0"
+version = "v1.3.1"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -4,6 +4,17 @@ linkTitle: Release Notes
 weight: 13
 draft: false
 ---
+### v1.3.1
+Fixes:
+
+- Resolved an issue where the Verrazzano uninstall deleted additional namespaces when deleting Rancher components.
+- Fixed IngressTrait controller to support Services as component workloads.
+- Added liveness probe for the AuthProxy NGINX server.
+- Added support for dynamic configuration overrides to Verrazzano components from various monitored sources, including ConfigMaps, Secrets, and Values referenced in the Verrazzano CR.
+- Added support for JWT authentication and authorization policy specification for applications.
+- Added support for Prometheus ServiceMonitor and PodMonitor CRs deployed using Prometheus Operator.
+- Updated Keycloak image to fix CVEs.
+
 ### v1.3.0
 Features:
 

--- a/content/en/docs/setup/prereqs.md
+++ b/content/en/docs/setup/prereqs.md
@@ -26,7 +26,7 @@ You can install Verrazzano on the following Kubernetes versions.
 | 1.0        | 2021-08-02   | 1.0.4                | 2021-12-20                | 1.18, 1.19, 1.20 |
 | 1.1        | 2021-12-16   | 1.1.2                | 2022-03-09                | 1.19, 1.20, 1.21 |
 | 1.2        | 2022-03-14   | 1.2.2                | 2022-05-10                | 1.19, 1.20, 1.21 |
-| 1.3        | 2022-05-24   | 1.3.0                | 2022-05-24                | 1.21, 1.22, 1.23 |
+| 1.3        | 2022-05-24   | 1.3.1                | 2022-06-21                | 1.21, 1.22, 1.23 |
 
 For more information, see [Kubernetes Release Documentation](https://kubernetes.io/releases/).
 For platform specific details, see [Verrazzano platform setup]({{< relref "/docs/setup/platforms/_index.md" >}}).


### PR DESCRIPTION
Backport the RNs for v1.3.1 and update params.toml accordingly.