### PR TITLE
VZ-6048 Update metrics descriptions for plain Kubernetes workloads

### DIFF
--- a/content/en/docs/applications/_index.md
+++ b/content/en/docs/applications/_index.md
@@ -211,9 +211,10 @@ See the [API documentation]({{< relref "/docs/reference/api/oam/ingresstrait.md"
 
 ### MetricsTrait
 The MetricsTrait provides a simplified integration with the Prometheus service included in the Verrazzano platform.
-The `verrazzano-application-operator` processes each MetricsTrait and does two things:
+The `verrazzano-application-operator` processes each MetricsTrait and does three things:
 - Updates the workload's annotations to provide metrics source information.
-- Updates the Prometheus' metrics scrape configuration with metrics scrape targets.
+- Creates a Service Monitor or Pod Monitor for the target workload
+- Updates an external Prometheus' metrics scrape configuration with metrics scrape targets.
 The Verrazzano platform will automatically apply a MetricsTrait to every Component with a supported workload.
 
 The following sample shows the a MetricsTrait that was automatically applied.

--- a/content/en/docs/monitoring/metrics/metrics.md
+++ b/content/en/docs/monitoring/metrics/metrics.md
@@ -69,106 +69,43 @@ For example, for the previous metric source:
 
 ### Standard Kubernetes workloads
 
-Verrazzano enables metric sources for Kubernetes workloads deployed without OAM components.
+Verrazzano supports enabling metric sources for Kubernetes workloads deployed without OAM components.
 Verrazzano supports the following workload types: Deployments, ReplicaSets, StatefulSets, and Pods.
-To enable metrics for Kubernetes workloads, you must label the workload namespace with `verrazzano-managed=true`.
+To enable metrics for Kubernetes workloads, you must label the workload namespace with `verrazzano-managed=true`, and
+create ServiceMonitor or PodMonitor resources as applicable, for your workloads. For details on ServiceMonitor and
+PodMonitor, refer to the [Prometheus Operator documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md). 
 
-#### Metrics Template
+When creating the ServiceMonitor or PodMonitor for your workload, include the label `release`, with the value
+`prometheus-operator` on the monitor resource.
 
-A [Metrics Template]({{< relref "/docs/reference/api/Verrazzano/metricstemplate.md" >}}) is a custom resource created by Verrazzano to manage metrics configurations for standard Kubernetes workloads.
-Metrics templates can be placed in the workload namespace or the `verrazzano-system` namespace.
-By default, Verrazzano installs a metrics template named `standard-k8s-metrics-template` in the `verrazzano-system` namespace.
-This metrics template handles all the aforementioned workload types.
-If the default metrics template does not meet your requirements, then you can create your own metrics templates to extend and alter its functionality.
+#### Verify metrics collection
 
-
-As outlined in the [API]({{< relref "/docs/reference/api/Verrazzano/metricstemplate.md" >}}), the metrics template contains a `workloadSelector` field that specifies the resources for which the template applies.
-If you want to forgo the workload selection and manually specify a template, you can add the annotation `app.verrazzano.io/metrics=<template-name>`
-to the namespace of the workload or to the workload itself.
-Additionally, you can opt out of metrics for your namespace or workload by setting the annotation `app.verrazzano.io/metrics=none`.
-
-The template matching precedence is as follows:
-
-1. A workload is annotated.
-
-   a. A template matching the annotation value is found in the workload namespace.
-
-   b. A template matching the annotation value is found in the `verrazzano-system` namespace.
-
-   c. No template is found, an error is recorded, and metrics are not processed for this workload.
-
-2. A workload namespace is annotated.
-
-   a. A template matching the annotation value is found in the workload namespace.
-
-   b. A template matching the annotation value is found in the `verrazzano-system` namespace.
-
-   c. No template is found, an error is recorded, and metrics are not processed for this namespace.
-
-3. No annotation is present.
-
-   a. A template in the workload namespace matches the workload through the `workloadSelector` field.
-
-   b. A template in the `verrazzano-system` namespace matches the workload through the `workloadSelector` field.
-
-   c. No templates match the workload and metrics are not processed for this workload.
-
-If a workload with no annotations matches multiple templates in a namespace, there is no guaranteed precedence in template matching.
-If this is the case, it is more reliable to specify the template you require by using an annotation.
-
-To verify that the metrics template process was successful, follow these steps:
+To verify that the metrics are being collected for your workload, follow these steps:
 1. Access the [Prometheus console]({{< relref "/docs/access/_index.md" >}}).
-1. From the console, use the navigation bar to access Status/Targets.
-1. On this page, you will see a target name with this formatting: `<workload-namespace>_<workload-name>_<workload-type>`.
-1. Copy this job name for use in future queries.
-1. Verify that the State of this target is `UP`.
-1. Next, use the navigation bar to access the Graph.
-1. Here, use the job name you copied to construct this expression: `{job="<job_name>"}`
-1. Use the graph to execute this expression and verify that you see application metrics appear.
+2. From the console, use the navigation bar to access Status/Targets.
+3. On this page, you will see a target name with this formatting: `<monitor-type>/<workload-namespace>_<workload-name>_<workload-type>`, where "monitor-type" may be serviceMonitor or podMonitor, depending on the type of monitor resource you created for your workload.
+4. Copy this job name for use in future queries.
+5. Verify that the State of this target is `UP`.
+6. Next, use the navigation bar to access the Graph.
+7. Here, use the job name you copied to construct this expression: `{job="<job_name>"}`
+8. Use the graph to execute this expression and verify that you see application metrics appear.
 
-#### Prometheus overrides
+#### Legacy workloads
 
-The `standard-k8s-metrics-template` metrics template installed by Verrazzano uses the following pod annotations to populate the Prometheus configuration.
-If not specified, Verrazzano will use these default values:
+Standard Kubernetes workloads that were metrics sources in earlier versions of Verrazzano (1.3.x or older), will continue
+to be supported when upgrading to later versions of Verrazzano.
 
-```
-Annotations:  prometheus.io/path: /metrics
-              prometheus.io/port: 8080
-              prometheus.io/scrape: true
-```
+For workloads that used the legacy default metrics template, Verrazzano will create a ServiceMonitor in the workload's
+namespace, to ensure that metrics continue to be scraped. You can make any ongoing changes to the metrics source configuration,
+by editing the ServiceMonitor.
 
-To alter these values, annotate the workload pod with the corresponding annotations.
-For example, if you want to change the metrics path, then add the following to a Deployment definition:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: hello-helidon-deployment
-  namespace: hello-helidon
-  annotations:
-    app.verrazzano.io/metrics: standard-k8s-metrics-template
-spec:
-  template:
-    metadata:
-      # add path annotation to the pod template
-      annotations:
-        prometheus.io/path: "/custom/metrics/path"
-```
-
-#### Prometheus configuration
-
-If you want to create your own metrics template, you will need to construct a [Prometheus `scrape config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
-The `scrape config` uses [Go Templates](https://pkg.go.dev/text/template) to generate configuration values based on Kubernetes resources.
-You can reference values in the `workload` and `namespace` definitions for use in the `scrape config`.
-For example, the default `scrape config` references the workload namespace field through this reference: `.workload.metadata.namespace`.
-Do not include the `job_name` field in your `scrape config` as it will be generated by Verrazzano.
-For guidance on how to construct a Prometheus `scrape config`, reference the `scrapeConfigTemplate` section in the [Metrics Template]({{< relref "/docs/reference/api/Verrazzano/metricstemplate.md" >}}) example.
+For workloads that used a legacy custom metrics template, Verrazzano will configure the Prometheus Operator to ensure
+that metrics continue to be scraped.
 
 ### Metrics server
 
-- Single pod per cluster.
-- Named `vmi-system-prometheus-*` in `verrazzano-system` namespace.
+- Verrazzano installs Prometheus Operator in the `verrazzano-monitoring` namespace. 
+- A single Prometheus pod is created by Prometheus Operator, in the same namespace.
 - Discovers exposed metrics source endpoints.
 - Scrapes metrics from metrics sources.
 - Responsible for exposing all metrics.

--- a/content/en/docs/monitoring/metrics/metrics.md
+++ b/content/en/docs/monitoring/metrics/metrics.md
@@ -70,10 +70,8 @@ For example, for the previous metric source:
 ### Standard Kubernetes workloads
 
 Verrazzano supports enabling metric sources for Kubernetes workloads deployed without OAM components.
-Verrazzano supports the following workload types: Deployments, ReplicaSets, StatefulSets, and Pods.
-To enable metrics for Kubernetes workloads, you must label the workload namespace with `verrazzano-managed=true`, and
-create ServiceMonitor or PodMonitor resources as applicable, for your workloads. For details on ServiceMonitor and
-PodMonitor, refer to the [Prometheus Operator documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md). 
+To enable metrics for Kubernetes workloads, you must create a ServiceMonitor or PodMonitor as applicable. 
+For details on ServiceMonitor and PodMonitor, refer to the [Prometheus Operator documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md). 
 
 When creating the ServiceMonitor or PodMonitor for your workload, include the label `release`, with the value
 `prometheus-operator` on the monitor resource.
@@ -83,8 +81,8 @@ When creating the ServiceMonitor or PodMonitor for your workload, include the la
 To verify that the metrics are being collected for your workload, follow these steps:
 1. Access the [Prometheus console]({{< relref "/docs/access/_index.md" >}}).
 2. From the console, use the navigation bar to access Status/Targets.
-3. On this page, you will see a target name with this formatting: `<monitor-type>/<workload-namespace>_<workload-name>_<workload-type>`, where "monitor-type" may be serviceMonitor or podMonitor, depending on the type of monitor resource you created for your workload.
-4. Copy this job name for use in future queries.
+3. On this page, you will see a target name with this formatting: `<monitor-type>/<workload-namespace>_<workload-name>_<workload-type>`, where "monitor-type" may be Service Monitor or Pod Monitor.
+4. Copy this job name from the target labels for use in future queries.
 5. Verify that the State of this target is `UP`.
 6. Next, use the navigation bar to access the Graph.
 7. Here, use the job name you copied to construct this expression: `{job="<job_name>"}`

--- a/content/en/docs/reference/API/Verrazzano/MetricsTemplate.md
+++ b/content/en/docs/reference/API/Verrazzano/MetricsTemplate.md
@@ -5,85 +5,10 @@ weight: 2
 draft: false
 ---
 
-The Metrics Template CRD contains the metrics configuration for default Kubernetes workloads.
-Here is the default Metrics Template that Verrazzano installs.
+Due to the integration of the Prometheus Operator, the Metrics Template will no longer be used to provide metrics from default Kubernetes workloads.
+Instead, we recommend using [Service Monitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) and [Pod Monitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor)
 
-```
-apiVersion: app.verrazzano.io/v1alpha1
-kind: MetricsTemplate
-metadata:
-  name: standard-k8s-metrics-template
-  namespace: verrazzano-system
-spec:
-  workloadSelector:
-    apiGroups: ["apps", ""]
-    apiVersions: ["v1"]
-    resources: ["deployment", "statefulset", "replicaset", "pod"]
-  prometheusConfig:
-    targetConfigMap:
-      namespace: verrazzano-system
-      name: vmi-system-prometheus-config
-    scrapeConfigTemplate: |
-      kubernetes_sd_configs:
-        - namespaces:
-            names:
-            - {{`{{.workload.metadata.namespace}}`}}
-          role: pod
-      relabel_configs:
-        - action: replace
-          replacement: local
-          source_labels: null
-          target_label: verrazzano_cluster
-        - action: keep
-          regex: {{`{{index .workload.metadata.labels "app.verrazzano.io/workload"}}`}};true
-          source_labels:
-            - __meta_kubernetes_pod_label_app_verrazzano_io_workload
-            - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-        - action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          source_labels:
-            - __address__
-            - __meta_kubernetes_pod_annotation_prometheus_io_port
-          target_label: __address__
-        - action: replace
-          regex: (.*)
-          source_labels:
-            - __meta_kubernetes_pod_annotation_prometheus_io_path
-          target_label: __metrics_path__
-        - action: replace
-          regex: (.*)
-          replacement: $1
-          source_labels:
-            - __meta_kubernetes_namespace
-          target_label: namespace
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - action: replace
-          source_labels:
-            - __meta_kubernetes_pod_name
-          target_label: pod_name
-        - action: labeldrop
-          regex: (controller_revision_hash)
-        - action: replace
-          regex: .*/(.*)$
-          replacement: $1
-          source_labels:
-            - name
-          target_label: webapp
-      {{`{{ if index .namespace.metadata.labels "istio-injection" }}`}}
-      {{`{{ if eq (index .namespace.metadata.labels "istio-injection" ) "enabled" }}`}}
-      scheme: https
-      tls_config:
-        ca_file: /etc/istio-certs/root-cert.pem
-        cert_file: /etc/istio-certs/cert-chain.pem
-        insecure_skip_verify: true
-        key_file: /etc/istio-certs/key.pem
-      {{`{{ end }}`}}
-      {{`{{ end }}`}}
-```
-
-For more information on using the Metrics Template, see [Metrics Template]({{< relref "/docs/monitoring/metrics/metrics.md#metrics-template" >}}).
+For more information on setting up metrics for Kubernetes workloads, see [Verrazzano metrics]({{< relref "/docs/monitoring/metrics/metrics.md" >}}).
 
 #### MetricsTemplate
 


### PR DESCRIPTION
Fixes VZ-6048

This PR updates the guidance for metrics collection in plain Kubernetes workloads. Eventually, the Metrics Template will be depreciated. For now, I have inserted a guidance to use Prometheus Operator components instead