### PR TITLE
Remove empty gateway headings from OCNE setup guide

### DIFF
--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -91,17 +91,11 @@ Private Subnet Route Table Rules
 | `0.0.0.0/0`     | NAT Gateway    |
 | All Oracle Cloud Infrastructure Services| Service Gateway|
 
-**Internet Gateway**
-
-**NAT Gateway**
-
-**Service Gateway**
+### Compute Instances
 
 The following compute resources adhere to the guidelines provided in [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/).
 The attributes indicated (for example, Subnet, RAM, Shape, and Image) are recommendations that have been tested.
 Other values can be used if required.
-
-**Compute Instances**
 
 | Role                          | Subnet  | Suggested RAM | Compatible VM Shape | Compatible VM Image |
 |-------------------------------|---------|---------------|---------------------|---------------------|


### PR DESCRIPTION
There were three empty sections in the OCNE platform setup documentation, one for each type of OCI VCN Gateway.  Without any content, none of them are necessary.  There was also some strange formatting in the transition between the network section of the OCI example section to the compute section.  The order of lines was adjusted to make a heading for the compute section.