### PR TITLE
VZ-6390: Bump Rancher version

### DIFF
--- a/content/en/docs/setup/prereqs.md
+++ b/content/en/docs/setup/prereqs.md
@@ -71,5 +71,5 @@ component, its version, and a brief description.
 | Prometheus Adapter           | 0.9.1   | Provides metrics in support of pod autoscaling.                                      |
 | Prometheus Operator          | 0.55.1  | Provides management for Prometheus monitoring tools.                                 |
 | Prometheus Pushgateway       | 1.4.2   | Allows ephemeral and batch jobs to expose their metrics to Prometheus.               |
-| Rancher                      | 2.6.4   | Manages multiple Kubernetes clusters.                                                |
+| Rancher                      | 2.6.5   | Manages multiple Kubernetes clusters.                                                |
 | WebLogic Kubernetes Operator | 3.4.0   | Assists with deploying and managing WebLogic domains.                                |


### PR DESCRIPTION
Update the "Installed Components" table to reference new Rancher 2.6.5 version.