### PR TITLE
Reverse OLCNE install guide sections

### DIFF
--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -17,8 +17,8 @@ Deploy Oracle Cloud Native Environment with the Kubernetes module, following ins
 
 ### Notes
 
-The oci-ccm module does not elect a default StorageClass or configure policies for the CSIDrivers that it installs.  A
-reasonable choice is the "oci-bv" StorageClass with its CSIDriver configured with the "File" group policy.
+The `oci-ccm` module does not elect a default `StorageClass` or configure policies for the `CSIDrivers` that it installs.  A
+reasonable choice is the `oci-bv` `StorageClass` with its `CSIDriver` configured with the `File` group policy.
 
 ```
 kubectl patch sc oci-bv -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -37,8 +37,8 @@ EOF
 To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
 
 ## Examples
-
-### Oracle Cloud Infrastructure
+<details>
+<summary>Oracle Cloud Infrastructure</summary>
 The following is an example of Oracle Cloud Infrastructure that can be used to evaluate Verrazzano installed on Oracle Cloud Native Environment.
 If other environments are used, the capacity and configuration should be similar.
 
@@ -78,10 +78,6 @@ Security List / Ingress Rules
 |No       | `10.0.0.0/16` | TCP      | All          | 22                |            |SSH                  |
 |No       | `10.0.0.0/24` | TCP      | All          | 31443             |            |HTTPS load balancer  |
 |No       | `10.0.0.0/24` | TCP      | All          | 32443             |            |HTTPS load balancer  |
-|No       | `10.0.1.0/24` | UDP      | All          | 111               |            |NFS                  |
-|No       | `10.0.1.0/24` | TCP      | All          | 111               |            |NFS                  |
-|No       | `10.0.1.0/24` | UDP      | All          | 2048              |            |NFS                  |
-|No       | `10.0.1.0/24` | TCP      | All          | 2048-2050         |            |NFS                  |
 |No       | `10.0.1.0/24` | TCP      | All          | 2379-2380         |            |Kubernetes etcd      |
 |No       | `10.0.1.0/24` | TCP      | All          | 6443              |            |Kubernetes API Server|
 |No       | `10.0.1.0/24` | TCP      | All          | 6446              |            |MySQL                |
@@ -130,3 +126,4 @@ Other values can be used if required.
 | Kubernetes Worker Node 1      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
 | Kubernetes Worker Node 2      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
 | Kubernetes Worker Node 3      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
+</details>

--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -6,14 +6,32 @@ weight: 7
 draft: false
 ---
 
-## Prepare for the Oracle Cloud Native Environment installation
-[Oracle Cloud Native Environment](https://docs.oracle.com/en/operating-systems/olcne/) can be installed in several different types of environments.
-These range from physical, on-premises hardware to virtualized cloud infrastructure.
-The Oracle Cloud Native Environment installation instructions assume that networking and compute resources already exist.
-The basic infrastructure requirements are a network with a public and private subnet
-and a set of hosts connected to those networks.
 
-### Oracle Cloud Infrastructure example
+## Install Oracle Cloud Native Environment
+Deploy Oracle Cloud Native Environment with the Kubernetes module, following instructions from [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/).
+* Use a single Kubernetes control plane node.
+* Skip the Kubernetes API load balancer ([load balancer](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#install-lb)).
+* Use private CA certificates ([private certs](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#certs-private)).
+* Install a Kubernetes network load balancer implementation, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/oci.html#oci) or [MetalLB](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/metallb.html#metallb).
+* Install a Container Storage Interface Driver, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/oci.html#oci) or [Gluster](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/gluster.html#gluster).
+
+### Notes
+
+The oci-ccm module does not elect a default StorageClass or configure policies for the CSIDrivers that it installs.  A
+reasonable choice is the "oci-bv" StorageClass with its CSIDriver configured with the "File" group policy.
+
+```
+kubectl patch sc oci-bv -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+kubectl patch csidriver blockvolume.csi.oraclecloud.com -p '{"spec": {"fsGroupPolicy": "File"}}'
+```
+
+## Next steps
+
+To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
+
+## Examples
+
+### Oracle Cloud Infrastructure
 The following is an example of Oracle Cloud Infrastructure that can be used to evaluate Verrazzano installed on Oracle Cloud Native Environment.
 If other environments are used, the capacity and configuration should be similar.
 
@@ -105,15 +123,3 @@ Other values can be used if required.
 | Kubernetes Worker Node 1      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
 | Kubernetes Worker Node 2      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
 | Kubernetes Worker Node 3      | Private | 32GB          | VM.Standard3.Flex    | Oracle Linux 7.9    |
-
-## Install Oracle Cloud Native Environment
-Deploy Oracle Cloud Native Environment with the Kubernetes module, following instructions from [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/).
-* Use a single Kubernetes control plane node.
-* Skip the Kubernetes API load balancer ([load balancer](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#install-lb)).
-* Use private CA certificates ([private certs](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#certs-private)).
-* Install a Kubernetes network load balancer implementation, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/oci.html#oci) or [MetalLB](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/metallb.html#metallb).
-* Install a Container Storage Interface Driver, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/oci.html#oci) or [Gluster](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/gluster.html#gluster).
-
-## Next steps
-
-To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).

--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -22,7 +22,14 @@ reasonable choice is the "oci-bv" StorageClass with its CSIDriver configured wit
 
 ```
 kubectl patch sc oci-bv -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-kubectl patch csidriver blockvolume.csi.oraclecloud.com -p '{"spec": {"fsGroupPolicy": "File"}}'
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: blockvolume.csi.oraclecloud.com
+spec:
+  fsGroupPolicy: File
+EOF
 ```
 
 ## Next steps

--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -8,7 +8,7 @@ draft: false
 
 
 ## Install Oracle Cloud Native Environment
-Deploy Oracle Cloud Native Environment with the Kubernetes module, following instructions from [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/).
+Deploy Oracle Cloud Native Environment with the Kubernetes module, following instructions from [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/).
 * Use a single Kubernetes control plane node.
 * Skip the Kubernetes API load balancer ([load balancer](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#install-lb)).
 * Use private CA certificates ([private certs](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#certs-private)).


### PR DESCRIPTION
This PR includes to improvements.  First, the order of the install guide and OCI setup instructions is reversed, making easier to see the installation instructions.  Second, a kubectl snippet is included to show a possible oci-ccm configuration that will work for verrazzano.