### PR TITLE
Documentation for vz analyze and vz bug-report commands

### DIFF
--- a/content/en/docs/setup/cli/_index.md
+++ b/content/en/docs/setup/cli/_index.md
@@ -65,6 +65,7 @@ vz [command] [flags]
 | Command     | Definition                                                 |
 |-------------|------------------------------------------------------------|
 | `analyze`   | Analyze cluster                                            |
+| `bug-report`| Collect information from the cluster to report an issue    | 
 | `help`      | Help about any command                                     |
 | `install`   | Install Verrazzano                                         |
 | `status`    | Status of the Verrazzano installation and access endpoints |

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -45,15 +45,15 @@ For example, the following commands create a bug report by including additional 
 The values specified for the flag --include-namespaces are case-sensitive.
 ```
 
-### Available Options
+### Available options
 
 | Command                            | Definition                                                                                                                                                                                    |
 |------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-h, --help `                      | help for bug-report                                                                                                                                                                           |
-| `-i, --include-namespaces strings` | A comma separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times like `--include-namespaces ns1 --include-namespaces ns...` |
-| `-r, --report-file string`         | The report file to be created by bug-report command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                             |
+| `-i, --include-namespaces strings` | A comma-separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...` |
+| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                           |
 
-### Available Flags
+### Available flags
 
 These flags apply to all the commands.
 

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -1,57 +1,38 @@
 ---
-title: Verrazzano Bug Report Tool
-linkTitle: Verrazzano Bug Report Tool
+title: Bug Report Tool
+linkTitle: Bug Report Tool
 weight: 1
-description: Use the Verrazzano Bug Report Tool to selectively capture the information from cluster and create an archive of it
+description: Use the Bug Report Tool to capture and archive cluster information
 draft: false
 ---
 
 
-The Verrazzano command `vz bug-report` aims to selectively capture the information from the cluster and create an archive `(.tar.gz)` to help diagnose problems. The archive should be sufficient for the support / development teams to analyze the issue and provide a recommendation.
+Use the `$ vz bug-report` command to selectively capture cluster information and create an archive (`.tar.gz`) file to help diagnose problems. The archive file will help support and development teams analyze issues and provide recommendations.
 
-## CLI Setup
-Follow the steps here to setup vz cli: https://verrazzano.io/latest/docs/setup/cli/
+## CLI setup
+To set up the `$ vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
 
-## Use the `vz bug-report` tool
+## Use the `$ vz bug-report` tool
 
-The `vz bug-report` is a CLI tool captures cluster data based on provided kubeconfig and context. 
-Note that the data captured by this tool might include sensitive information. Please examine the contents of the bug report for any sensitive data before sharing with Verrazzano support / development teams.
-
-To perform a snapshot of a cluster into a tar file named `my-bug-report.tar.gz`:
+To create a cluster snapshot in a TAR file named `my-bug-report.tar.gz`:
 
 `$ vz bug-report --report-file my-bug-report.tar.gz`
 
+We suggest that you review the contents of the bug report before sharing it with support and development teams.
+
 ### Usage information
 
-Use the following syntax to run `vz` commands from your terminal window.
+Use the following syntax to run `$ vz` commands from your terminal window.
 ```shell
-vz bug-report [flags]
+$ vz bug-report [flags]
 ```
-### Examples
-```
-# Create a bug report bugreport.tar.gz by collecting data from the cluster
-vz bug-report --report-file bugreport.tar.gz
-
-When the --report-file is not provided, the command attempts to create bug-report.tar.gz in the current directory.
-
-# Create a bug report bugreport.tgz, including additional namespace ns1 from the cluster
-vz bug-report --report-file bugreport.tgz --include-namespaces ns1
-
-The flag --include-namespaces accepts comma separated values. The flag can also be specified multiple times.
-For example, the following commands create a bug report by including additional namespaces ns1, ns2 and ns3
-   a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
-   b. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3
-
-The values specified for the flag --include-namespaces are case-sensitive.
-```
-
 ### Available options
 
-| Command                            | Definition                                                                                                                                                                                        |
-|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-h, --help `                      | Help for `vz bug-report` command.                                                                                                                                                                 |
-| `-i, --include-namespaces strings` | A comma-separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...` |
-| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                             |
+| Command                            | Definition                                                                                                                                                                                           |
+|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-h, --help `                      | Help for `$ vz bug-report` command.                                                                                                                                                                  |
+| `-i, --include-namespaces strings` | A comma-separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...`    |
+| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                                |
 
 ### Available flags
 
@@ -61,3 +42,21 @@ These flags apply to all the commands.
 |-----------------------|----------------------------------------------|
 | `--context string`    | The name of the `kubeconfig` context to use. |
 | `--kubeconfig string` | Path to the `kubeconfig` file to use.        |
+
+### Examples
+```
+# Create a bug report bugreport.tar.gz by collecting data from the cluster
+$ vz bug-report --report-file bugreport.tar.gz
+
+When the --report-file is not provided, the command creates bug-report.tar.gz in the current directory.
+
+# Create a bug report bugreport.tgz, including additional namespace ns1 from the cluster
+$ vz bug-report --report-file bugreport.tgz --include-namespaces ns1
+
+The flag --include-namespaces accepts comma-separated values. The flag can be specified multiple times.
+For example, the following commands create a bug report by including additional namespaces ns1, ns2 and ns3
+   a. $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
+   b. $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3
+
+The values specified for the flag --include-namespaces are case-sensitive.
+```

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -1,0 +1,117 @@
+---
+title: Verrazzano Bug Report Tools
+linkTitle: Verrazzano Bug Report Tools
+weight: 1
+description: Use the Verrazzano Bug Report Tools to selectively capture the information from cluster and create an archive of it
+draft: false
+---
+
+
+The Verrazzano command `vz bug-report` aims to selectively capture the information from the cluster and create an archive `(.tar.gz)` to help diagnose problems. The archive should be sufficient for the support / development teams to analyze the issue and provide a recommendation.
+
+## CLI Setup
+Follow the steps here to setup vz cli: https://verrazzano.io/latest/docs/setup/cli/
+
+## Use the `vz bug-report` tool
+
+The `vz bug-report` is a CLI tool which runs various `kubectl` and `helm` commands against a cluster.
+Note that the data captured by this tool might include sensitive information. This data is under your control; you can choose whether to share it.
+
+The directory structure created by the `vz bug-report` tool, for a specific cluster snapshot, appears as follows:
+
+    $ CAPTURE_DIR
+      cluster-snapshot
+        directory per namespace (a directory at this level is assumed to represent a namespace)
+          acme-orders.json
+          application-configurations.json
+          certificate-requests.json
+          cluster-role-bindings.json
+          cluster-roles.json
+          cluster-roles.json
+          coherence.json
+          components.json
+          {CONFIGNAME}.configmap (a file at this level for each configmap in the namespace)
+          daemonsets.json
+          deployments.json
+          events.json
+          gateways.json
+          ingress-traits.json
+          jobs.json
+          multicluster-application-configurations.json
+          multicluster-components.json
+          multicluster-config-maps.json
+          multicluster-logging-scopes.json
+          multicluster-secrets.json
+          namespace.json
+          persistent-volume-claims.json
+          persistent-volumes.json
+          pods.json
+          replicasets.json
+          replication-controllers.json
+          role-bindings.json
+          services.json
+          verrazzano-managed-clusters.json
+          verrazzano-projects.json
+          virtualservices.json
+          weblogic-domains.json
+          directory per pod (a directory at this level is assumed to represent a specific pod)
+            logs.txt (includes logs for all containers and initContainers)
+        cluster-issuers.txt
+        configmap_list.out
+        crd.json
+        es_indexes.out
+        helm-ls.json
+        helm-version.out
+        images-on-nodes.csv
+        ingress.json
+        kubectl-version.json
+        network-policies.json
+        network-policies.txt
+        nodes.json
+        pv.json
+        verrazzano_resources.json
+
+To perform a snapshot of a cluster into a tar file named `my-bug-report.tar.gz`:
+
+`$ vz bug-report --report-file my-bug-report.tar.gz`
+
+### Usage information
+
+Use the following syntax to run `vz` commands from your terminal window.
+```shell
+vz bug-report [flags]
+```
+### Examples
+```
+# Create a bug report bugreport.tar.gz by collecting data from the cluster
+vz bug-report --report-file bugreport.tar.gz
+
+When the --report-file is not provided, the command attempts to create bug-report.tar.gz in the current directory.
+
+# Create a bug report bugreport.tgz, including additional namespace ns1 from the cluster
+vz bug-report --report-file bugreport.tgz --include-namespaces ns1
+
+The flag --include-namespaces accepts comma separated values. The flag can also be specified multiple times.
+For example, the following commands create a bug report by including additional namespaces ns1, ns2 and ns3
+   a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
+   b. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3
+
+The values specified for the flag --include-namespaces are case-sensitive.
+```
+
+### Available Options
+
+| Command                            | Definition                                                                                                                                                                                    |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-h, --help `                      | help for bug-report                                                                                                                                                                           |
+| `-i, --include-namespaces strings` | A comma separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times like `--include-namespaces ns1 --include-namespaces ns...` |
+| `-r, --report-file string`         | The report file to be created by bug-report command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                             |
+
+### Available Flags
+
+These flags apply to all the commands.
+
+| Flag                  | Definition                                   |
+|-----------------------|----------------------------------------------|
+| `--context string`    | The name of the `kubeconfig` context to use. |
+| `--kubeconfig string` | Path to the `kubeconfig` file to use.        |

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -6,7 +6,6 @@ description: Use the Bug Report Tool to capture and archive cluster information
 draft: false
 ---
 
-
 Use the `$ vz bug-report` command to selectively capture cluster information and create an archive (`.tar.gz`) file to help diagnose problems. The archive file will help support and development teams analyze issues and provide recommendations.
 
 ## CLI setup

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -1,8 +1,8 @@
 ---
-title: Verrazzano Bug Report Tools
-linkTitle: Verrazzano Bug Report Tools
+title: Verrazzano Bug Report Tool
+linkTitle: Verrazzano Bug Report Tool
 weight: 1
-description: Use the Verrazzano Bug Report Tools to selectively capture the information from cluster and create an archive of it
+description: Use the Verrazzano Bug Report Tool to selectively capture the information from cluster and create an archive of it
 draft: false
 ---
 
@@ -14,62 +14,8 @@ Follow the steps here to setup vz cli: https://verrazzano.io/latest/docs/setup/c
 
 ## Use the `vz bug-report` tool
 
-The `vz bug-report` is a CLI tool which runs various `kubectl` and `helm` commands against a cluster.
-Note that the data captured by this tool might include sensitive information. This data is under your control; you can choose whether to share it.
-
-The directory structure created by the `vz bug-report` tool, for a specific cluster snapshot, appears as follows:
-
-    $ CAPTURE_DIR
-      cluster-snapshot
-        directory per namespace (a directory at this level is assumed to represent a namespace)
-          acme-orders.json
-          application-configurations.json
-          certificate-requests.json
-          cluster-role-bindings.json
-          cluster-roles.json
-          cluster-roles.json
-          coherence.json
-          components.json
-          {CONFIGNAME}.configmap (a file at this level for each configmap in the namespace)
-          daemonsets.json
-          deployments.json
-          events.json
-          gateways.json
-          ingress-traits.json
-          jobs.json
-          multicluster-application-configurations.json
-          multicluster-components.json
-          multicluster-config-maps.json
-          multicluster-logging-scopes.json
-          multicluster-secrets.json
-          namespace.json
-          persistent-volume-claims.json
-          persistent-volumes.json
-          pods.json
-          replicasets.json
-          replication-controllers.json
-          role-bindings.json
-          services.json
-          verrazzano-managed-clusters.json
-          verrazzano-projects.json
-          virtualservices.json
-          weblogic-domains.json
-          directory per pod (a directory at this level is assumed to represent a specific pod)
-            logs.txt (includes logs for all containers and initContainers)
-        cluster-issuers.txt
-        configmap_list.out
-        crd.json
-        es_indexes.out
-        helm-ls.json
-        helm-version.out
-        images-on-nodes.csv
-        ingress.json
-        kubectl-version.json
-        network-policies.json
-        network-policies.txt
-        nodes.json
-        pv.json
-        verrazzano_resources.json
+The `vz bug-report` is a CLI tool captures cluster data based on provided kubeconfig and context. 
+Note that the data captured by this tool might include sensitive information. Please examine the contents of the bug report for any sensitive data before sharing with Verrazzano support / development teams.
 
 To perform a snapshot of a cluster into a tar file named `my-bug-report.tar.gz`:
 

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -47,11 +47,11 @@ The values specified for the flag --include-namespaces are case-sensitive.
 
 ### Available options
 
-| Command                            | Definition                                                                                                                                                                                    |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-h, --help `                      | help for bug-report                                                                                                                                                                           |
+| Command                            | Definition                                                                                                                                                                                        |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-h, --help `                      | Help for `vz bug-report` command.                                                                                                                                                                 |
 | `-i, --include-namespaces strings` | A comma-separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...` |
-| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                           |
+| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                             |
 
 ### Available flags
 

--- a/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VZBugReportCLI.md
@@ -1,27 +1,28 @@
 ---
-title: Bug Report Tool
-linkTitle: Bug Report Tool
-weight: 1
-description: Use the Bug Report Tool to capture and archive cluster information
+title: Bug Reports
+linkTitle: Bug Reports
+weight: 2
+description: Use the Bug Report command-line tool to capture and archive cluster information
 draft: false
 ---
 
-Use the `$ vz bug-report` command to selectively capture cluster information and create an archive (`.tar.gz`) file to help diagnose problems. The archive file will help support and development teams analyze issues and provide recommendations.
+Use the `vz bug-report` tool to selectively capture cluster information and create an archive (`*.tar.gz`) file to help diagnose problems. The archive file helps development and support teams analyze issues and provide recommendations.
 
 ## CLI setup
-To set up the `$ vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
 
-## Use the `$ vz bug-report` tool
+## Use the `vz bug-report` tool
 
-To create a cluster snapshot in a TAR file named `my-bug-report.tar.gz`:
-
-`$ vz bug-report --report-file my-bug-report.tar.gz`
+To create a bug report in a TAR file named `my-bug-report.tar.gz`:
+```shell
+$ vz bug-report --report-file my-bug-report.tar.gz
+```
 
 We suggest that you review the contents of the bug report before sharing it with support and development teams.
 
 ### Usage information
 
-Use the following syntax to run `$ vz` commands from your terminal window.
+Use the following syntax to run `vz` commands from your terminal window.
 ```shell
 $ vz bug-report [flags]
 ```
@@ -29,9 +30,9 @@ $ vz bug-report [flags]
 
 | Command                            | Definition                                                                                                                                                                                           |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-h, --help `                      | Help for `$ vz bug-report` command.                                                                                                                                                                  |
-| `-i, --include-namespaces strings` | A comma-separated list of additional namespaces to collect information from the cluster. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...`    |
-| `-r, --report-file string`         | The report file to be created by `bug-report` command, as a `.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                                |
+| `-h, --help `                      | Help for `vz bug-report` command.                                                                                                                                                                  |
+| `-i, --include-namespaces strings` | A comma-separated list of additional namespaces for collecting cluster information. This flag can be specified multiple times, such as `--include-namespaces ns1 --include-namespaces ns...`    |
+| `-r, --report-file string`         | The report file created by the `vz bug-report` command, as a `*.tar.gz` file. Defaults to `bug-report.tar.gz` in the current directory.                                                                |
 
 ### Available flags
 
@@ -43,19 +44,25 @@ These flags apply to all the commands.
 | `--kubeconfig string` | Path to the `kubeconfig` file to use.        |
 
 ### Examples
-```
-# Create a bug report bugreport.tar.gz by collecting data from the cluster
-$ vz bug-report --report-file bugreport.tar.gz
 
-When the --report-file is not provided, the command creates bug-report.tar.gz in the current directory.
+- Create a bug report file, `bugreport.tar.gz`, by collecting data from the cluster:
+   ```shell
+   $ vz bug-report --report-file bugreport.tar.gz
+   ```
 
-# Create a bug report bugreport.tgz, including additional namespace ns1 from the cluster
-$ vz bug-report --report-file bugreport.tgz --include-namespaces ns1
+  When `--report-file` is not provided, the command creates `bug-report.tar.gz` in the current directory.
 
-The flag --include-namespaces accepts comma-separated values. The flag can be specified multiple times.
-For example, the following commands create a bug report by including additional namespaces ns1, ns2 and ns3
-   a. $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
-   b. $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3
 
-The values specified for the flag --include-namespaces are case-sensitive.
-```
+- Create a bug report file, `bugreport.tar.gz`, including the additional namespace `ns1` from the cluster:
+   ```shell
+   $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1
+   ```
+
+- The flag `--include-namespaces` accepts comma-separated values and can be specified multiple times.
+For example, the following commands create a bug report by including additional namespaces `ns1`, `ns2`, and `ns3`:
+   ```shell
+   $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
+   $ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3
+   ```
+
+   The values specified for the flag `--include-namespaces` are case-sensitive.

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -12,7 +12,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here] ({{< relref "docs/setup/cli/_index.md" >}})
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}})
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -2,7 +2,7 @@
 title: Verrazzano Analysis Tools
 linkTitle: Verrazzano Analysis Tools
 weight: 1
-description: Use the Verrazzano Analysis Tools to analyze cluster dumps
+description: Use the Verrazzano Analysis Tools to analyze cluster snapshots
 draft: false
 ---
 
@@ -61,10 +61,10 @@ The `k8s-dump-cluster.sh` tool is a shell script which runs various `kubectl` an
 
 Note that the data captured by this script might include sensitive information. This data is under your control; you can choose whether to share it.
 
-The directory structure created by the `k8s-dump-cluster.sh` tool, for a specific cluster dump, appears as follows:
+The directory structure created by the `k8s-dump-cluster.sh` tool, for a specific cluster snapshot, appears as follows:
 
     $ CAPTURE_DIR
-      cluster-dump
+      cluster-snapshot
         directory per namespace (a directory at this level is assumed to represent a namespace)
           acme-orders.json
           application-configurations.json
@@ -117,35 +117,35 @@ The directory structure created by the `k8s-dump-cluster.sh` tool, for a specifi
 
 The script shows the `kubectl` and `helm` commands which are run. The basic structure, shown previously, is formed by running the command, `$ kubectl cluster-info dump --all-namespaces`, with additional data captured into that directory structure.
 
-To perform a dump of a cluster into a directory named `my-cluster-dump`:
+To perform a snapshot of a cluster into a directory named `my-cluster-snapshot`:
 
-`$ sh k8s-dump-cluster.sh -d my-cluster-dump`
+`$ sh k8s-dump-cluster.sh -d my-cluster-snapshot`
 
 ## Use the `vz analyze` tool
 
-The `vz analyze` tool analyzes data from a cluster dump captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
+The `vz analyze` tool analyzes data from a cluster snapshot captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
 
 Users, developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
 
-The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` dumps a cluster into a specific structure, which might contain data that you do not want to share. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
+The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` takes a snapshot of cluster into a specific structure, which might contain data that you do not want to share. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
 
-The `vz analyze` tool will find and analyze all cluster dump directories found under a specified root directory. This lets you create a directory to hold the cluster dumps of related clusters into sub-directories which the tool can analyze.
+The `vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters into sub-directories which the tool can analyze.
 
 For example:
 
-    my-cluster-dumps
+    my-cluster-snapshots
         CAPTURE_DIR-1
-            cluster-dump
+            cluster-snapshot
                 ...
         CAPTURE_DIR-2
-            cluster-dump
+            cluster-snapshot
                 ...
 
-The tool analyzes each cluster dump directory found; you need to provide only the single root directory.
+The tool analyzes each cluster snapshot directory found; you need to provide only the single root directory.
 
 To perform an analysis of the clusters:
 
-`$ vz analyze my-cluster-dumps`
+`$ vz analyze my-cluster-snapshots`
 
 ### Usage information
 

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -12,7 +12,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here] ( {{< relref "../../setup/cli/_index.md" >}} )
+To set up the `vz` command-line tool, follow the steps [here] ({{< relref "docs/setup/cli/_index.md" >}})
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -12,7 +12,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here]({{< relref "../../setup/cli/_index.md" >}})
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}})
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -12,7 +12,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}})
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "../../setup/cli/_index.md" >}})
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -17,7 +17,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 
 ### Linux Instructions
 
-Use these instructions to obtain the analysis tools on Linux machines.  
+Use these instructions to obtain the cluster snapshot analysis tool on Linux machines.
 
 #### Download the tooling
   ```
@@ -36,7 +36,7 @@ Use these instructions to obtain the analysis tools on Linux machines.
 
 ### Mac Instructions
 
-Use these instructions to obtain the analysis tools on Mac machines.
+Use these instructions to obtain the cluster snapshot analysis tool on Mac machines.
 
 #### Download the tooling
   ```

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -9,10 +9,10 @@ draft: false
 
 Verrazzano provides tooling which assists in troubleshooting issues in your environment:
 1. `k8s-dump-cluster.sh`
-2. `vz analyze`
+2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-Follow the steps here to setup vz cli: https://verrazzano.io/latest/docs/setup/cli/
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "/setup/cli/_index.md" >}})
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}
@@ -127,7 +127,7 @@ The `vz analyze` tool analyzes data from a cluster snapshot captured using `k8s-
 
 Users, developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
 
-The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` takes a snapshot of cluster into a specific structure, which might contain data that you do not want to share. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
+The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` takes a snapshot of a cluster and places it into a specific structure. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
 
 The `vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters into sub-directories which the tool can analyze.
 
@@ -154,16 +154,16 @@ Use the following syntax to run `vz` commands from your terminal window.
 vz analyze [flags]
 ```
 
-### Available Options
+### Available options
 
 | Command                  | Definition                                                                          |
 |--------------------------|-------------------------------------------------------------------------------------|
-| `--capture-dir string`   | Directory holding the captured data [Required]                                      |
-| `-h, --help`             | help for analyze                                                                    |
+| `--capture-dir string`   | Directory holding the captured data. (Required)                                      | 
+| `-h, --help`             | help for analyze.                                                                   |
 | `--report-file string`   | Name of report output file. (default stdout)                                        |
 | `--report-format string` | The format of the report output. Valid output format is "simple" (default "simple") |
 
-### Available Flags
+### Available flags
 
 These flags apply to all the commands.
 

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -9,10 +9,7 @@ draft: false
 
 Verrazzano provides tooling which assists in troubleshooting issues in your environment:
 1. `k8s-dump-cluster.sh`
-2. `vz analyze` - a command-line tool
-
-## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}})
+2. `$ vz analyze` - a command-line tool
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}
@@ -54,6 +51,8 @@ Use these instructions to obtain the analysis tools on Mac machines.
 {{< /tab >}}
 {{< /tabs >}}
 
+### CLI Setup
+To set up the `$ vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
 
 ## Use the `k8s-dump-cluster.sh` tool
 
@@ -121,15 +120,15 @@ To perform a snapshot of a cluster into a directory named `my-cluster-snapshot`:
 
 `$ sh k8s-dump-cluster.sh -d my-cluster-snapshot`
 
-## Use the `vz analyze` tool
+## Use the `$ vz analyze` tool
 
-The `vz analyze` tool analyzes data from a cluster snapshot captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
+The `$ vz analyze` tool analyzes data from a cluster snapshot captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
 
 Users, developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
 
 The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` takes a snapshot of a cluster and places it into a specific structure. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
 
-The `vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters into sub-directories which the tool can analyze.
+The `$ vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters into sub-directories which the tool can analyze.
 
 For example:
 
@@ -149,19 +148,19 @@ To perform an analysis of the clusters:
 
 ### Usage information
 
-Use the following syntax to run `vz` commands from your terminal window.
+Use the following syntax to run `$ vz` commands from your terminal window.
 ```shell
-vz analyze [flags]
+$ vz analyze [flags]
 ```
 
 ### Available options
 
-| Command                  | Definition                                                                          |
-|--------------------------|-------------------------------------------------------------------------------------|
-| `--capture-dir string`   | Directory holding the captured data. (Required)                                     | 
-| `-h, --help`             | Help for `vz analyze` command.                                                      |
-| `--report-file string`   | Name of report output file. (default stdout)                                        |
-| `--report-format string` | The format of the report output. Valid output format is "simple" (default "simple") |
+| Command                  | Definition                                                                           |
+|--------------------------|--------------------------------------------------------------------------------------|
+| `--capture-dir string`   | Directory holding the captured data. (Required)                                      | 
+| `-h, --help`             | Help for `$ vz analyze` command.                                                     |
+| `--report-file string`   | Name of report output file. (Default `stdout`)                                       |
+| `--report-format string` | The format of the report output. Valid output format is "simple". (Default "simple") |
 
 ### Available flags
 

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -9,10 +9,10 @@ draft: false
 
 Verrazzano provides tooling which assists in troubleshooting issues in your environment:
 1. `k8s-dump-cluster.sh`
-2. `verrazzano-analysis`
+2. `vz analyze`
 
 ## Tools Setup
-These tools are available for Linux and Mac: https://github.com/verrazzano/verrazzano/releases/.
+Follow the steps here to setup vz cli: https://verrazzano.io/latest/docs/setup/cli/
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}
@@ -26,20 +26,13 @@ Use these instructions to obtain the analysis tools on Linux machines.
   ```
    $ wget {{<release_asset_url k8s-dump-cluster.sh>}}
    $ wget {{<release_asset_url k8s-dump-cluster.sh.sha256>}}
-   $ wget {{<release_asset_url verrazzano-analysis-linux-amd64.tar.gz>}}
-   $ wget {{<release_asset_url verrazzano-analysis-linux-amd64.tar.gz.sha256>}}
   ```
 
 #### Verify the downloaded files
   ```
    $ sha256sum -c k8s-dump-cluster.sh.sha256
-   $ sha256sum -c verrazzano-analysis-linux-amd64.tar.gz.sha256
   ```
 
-#### Unpack the `verrazzano-analysis` binary
-  ```
-   $ tar xvf verrazzano-analysis-linux-amd64.tar.gz
-  ```
 {{< /tab >}}
 {{< tab tabName="macOS" >}}
 <br>
@@ -52,18 +45,10 @@ Use these instructions to obtain the analysis tools on Mac machines.
   ```
    $ wget {{<release_asset_url k8s-dump-cluster.sh>}}
    $ wget {{<release_asset_url k8s-dump-cluster.sh.sha256>}}
-   $ wget {{<release_asset_url verrazzano-analysis-darwin-amd64.tar.gz>}}
-   $ wget {{<release_asset_url verrazzano-analysis-darwin-amd64.tar.gz.sha256>}}
   ```
 #### Verify the downloaded files
   ```
    $ shasum -a 256 -c k8s-dump-cluster.sh.sha256
-   $ shasum -a 256 -c verrazzano-analysis-darwin-amd64.tar.gz.sha256
-  ```
-
-#### Unpack the `verrazzano-analysis` binary
-  ```
-   $ tar xvf verrazzano-analysis-darwin-amd64.tar.gz
   ```
 
 {{< /tab >}}
@@ -136,15 +121,15 @@ To perform a dump of a cluster into a directory named `my-cluster-dump`:
 
 `$ sh k8s-dump-cluster.sh -d my-cluster-dump`
 
-## Use the `verrazzano-analysis` tool
+## Use the `vz analyze` tool
 
-The `verrazzano-analysis` tool analyzes data from a cluster dump captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
+The `vz analyze` tool analyzes data from a cluster dump captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
 
 Users, developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
 
 The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` dumps a cluster into a specific structure, which might contain data that you do not want to share. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
 
-The `verrazzano-analysis` tool will find and analyze all cluster dump directories found under a specified root directory. This lets you create a directory to hold the cluster dumps of related clusters into sub-directories which the tool can analyze.
+The `vz analyze` tool will find and analyze all cluster dump directories found under a specified root directory. This lets you create a directory to hold the cluster dumps of related clusters into sub-directories which the tool can analyze.
 
 For example:
 
@@ -160,21 +145,29 @@ The tool analyzes each cluster dump directory found; you need to provide only th
 
 To perform an analysis of the clusters:
 
-`$ verrazzano-analysis my-cluster-dumps`
+`$ vz analyze my-cluster-dumps`
 
 ### Usage information
 
-```
-Usage: verrazzano-analysis [options] captured-data-directory
+Use the following syntax to run `vz` commands from your terminal window.
+```shell
+vz analyze [flags]
 ```
 
-| Parameter | Definition | Default |
-| --- | --- | --- |
-| `-actions` | Include actions in the report. | `true` |
-| `-help` | Display usage help. | |
-| `-info` | Include informational messages. | `true` |
-| `-minConfidence` | Minimum confidence threshold to report for issues, 0-10. | `0` |
-| `-minImpact` | Minimum impact threshold to report for issues, 0-10. | `0` |
-| `-reportFile` | Name of report output file. | Output to stdout. |
-| `-support` | Include support data in the report. | `true` |
-| `-version` | Display tool version. | |
+### Available Options
+
+| Command                  | Definition                                                                          |
+|--------------------------|-------------------------------------------------------------------------------------|
+| `--capture-dir string`   | Directory holding the captured data [Required]                                      |
+| `-h, --help`             | help for analyze                                                                    |
+| `--report-file string`   | Name of report output file. (default stdout)                                        |
+| `--report-format string` | The format of the report output. Valid output format is "simple" (default "simple") |
+
+### Available Flags
+
+These flags apply to all the commands.
+
+| Flag                  | Definition                                   |
+|-----------------------|----------------------------------------------|
+| `--context string`    | The name of the `kubeconfig` context to use. |
+| `--kubeconfig string` | Path to the `kubeconfig` file to use.        |

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -12,7 +12,7 @@ Verrazzano provides tooling which assists in troubleshooting issues in your envi
 2. `vz analyze` - a command-line tool
 
 ## Tools Setup
-To set up the `vz` command-line tool, follow the steps [here]({{< relref "/setup/cli/_index.md" >}})
+To set up the `vz` command-line tool, follow the steps [here] ( {{< relref "../../setup/cli/_index.md" >}} )
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -145,7 +145,7 @@ The tool analyzes each cluster snapshot directory found; you need to provide onl
 
 To perform an analysis of the clusters:
 
-`$ vz analyze my-cluster-snapshots`
+`$ vz analyze --capture-dir my-cluster-snapshots`
 
 ### Usage information
 

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -158,8 +158,8 @@ vz analyze [flags]
 
 | Command                  | Definition                                                                          |
 |--------------------------|-------------------------------------------------------------------------------------|
-| `--capture-dir string`   | Directory holding the captured data. (Required)                                      | 
-| `-h, --help`             | help for analyze.                                                                   |
+| `--capture-dir string`   | Directory holding the captured data. (Required)                                     | 
+| `-h, --help`             | Help for `vz analyze` command.                                                      |
 | `--report-file string`   | Name of report output file. (default stdout)                                        |
 | `--report-format string` | The format of the report output. Valid output format is "simple" (default "simple") |
 

--- a/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
+++ b/content/en/docs/troubleshooting/diagnostictools/VerrazzanoAnalysisTool.md
@@ -2,22 +2,23 @@
 title: Verrazzano Analysis Tools
 linkTitle: Verrazzano Analysis Tools
 weight: 1
-description: Use the Verrazzano Analysis Tools to analyze cluster snapshots
+description: Use the Verrazzano analysis tools to analyze cluster snapshots
 draft: false
 ---
 
 
 Verrazzano provides tooling which assists in troubleshooting issues in your environment:
-1. `k8s-dump-cluster.sh`
-2. `$ vz analyze` - a command-line tool
+1. `k8s-dump-cluster.sh` - a shell script tool
+2. `vz analyze` - a command-line tool
+
+## Download the shell script tool
 
 {{< tabs tabTotal="2" >}}
 {{< tab tabName="Linux" >}}
 <br>
 
-### Linux Instructions
 
-Use these instructions to obtain the cluster snapshot analysis tool on Linux machines.
+Use these instructions to obtain the shell script tool on Linux machines.
 
 #### Download the tooling
   ```
@@ -34,9 +35,8 @@ Use these instructions to obtain the cluster snapshot analysis tool on Linux mac
 {{< tab tabName="macOS" >}}
 <br>
 
-### Mac Instructions
 
-Use these instructions to obtain the cluster snapshot analysis tool on Mac machines.
+Use these instructions to obtain the shell script tool on Mac machines.
 
 #### Download the tooling
   ```
@@ -51,14 +51,12 @@ Use these instructions to obtain the cluster snapshot analysis tool on Mac machi
 {{< /tab >}}
 {{< /tabs >}}
 
-### CLI Setup
-To set up the `$ vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
+## Set up the CLI tool
+To set up the `vz` command-line tool, follow the steps [here]({{< relref "docs/setup/cli/_index.md" >}}).
 
-## Use the `k8s-dump-cluster.sh` tool
+## First, use the `k8s-dump-cluster.sh` tool
 
 The `k8s-dump-cluster.sh` tool is a shell script which runs various `kubectl` and `helm` commands against a cluster.
-
-Note that the data captured by this script might include sensitive information. This data is under your control; you can choose whether to share it.
 
 The directory structure created by the `k8s-dump-cluster.sh` tool, for a specific cluster snapshot, appears as follows:
 
@@ -114,21 +112,23 @@ The directory structure created by the `k8s-dump-cluster.sh` tool, for a specifi
         pv.json
         verrazzano_resources.json
 
+Note that the data captured by this script might include sensitive information; you can choose whether to share it.
+
 The script shows the `kubectl` and `helm` commands which are run. The basic structure, shown previously, is formed by running the command, `$ kubectl cluster-info dump --all-namespaces`, with additional data captured into that directory structure.
 
-To perform a snapshot of a cluster into a directory named `my-cluster-snapshot`:
+To create a cluster snapshot in a directory named `my-cluster-snapshot`:
+```shell
+$ sh k8s-dump-cluster.sh -d my-cluster-snapshot
+```
 
-`$ sh k8s-dump-cluster.sh -d my-cluster-snapshot`
+## Then, use the `vz analyze` tool
 
-## Use the `$ vz analyze` tool
-
-The `$ vz analyze` tool analyzes data from a cluster snapshot captured using `k8s-dump-cluster.sh`, reports the issues found, and prescribes related actions to take.  These tools are continually evolving with regard to what may be captured, the knowledge base of issues and actions, and the types of analysis that can be performed.
-
-Users, developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
+The `vz analyze` command-line tool analyzes data from a cluster snapshot captured using the shell script tool, reports the issues found, and prescribes related actions to take. Users,
+developers, and Continuous Integration (CI) can use this tooling to quickly identify the root cause of encountered problems, determine mitigation actions, and provide a sharable report with other users or tooling.
 
 The data that the analysis examines follows the structure created by the corresponding capture tooling. For example, `k8s-dump-cluster.sh` takes a snapshot of a cluster and places it into a specific structure. The tooling analyzes the data and provides you with a report, which identifies issues and provides you with actions to take.
 
-The `$ vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters into sub-directories which the tool can analyze.
+The `vz analyze` tool will find and analyze all cluster snapshot directories found under a specified root directory. This lets you create a directory to hold the cluster snapshots of related clusters in sub-directories, which the tool can analyze.
 
 For example:
 
@@ -143,26 +143,27 @@ For example:
 The tool analyzes each cluster snapshot directory found; you need to provide only the single root directory.
 
 To perform an analysis of the clusters:
-
-`$ vz analyze --capture-dir my-cluster-snapshots`
+```shell
+$ vz analyze --capture-dir my-cluster-snapshots
+```
 
 ### Usage information
 
-Use the following syntax to run `$ vz` commands from your terminal window.
+Use the following syntax to run `vz` commands from your terminal window.
 ```shell
 $ vz analyze [flags]
 ```
 
-### Available options
+#### Available options
 
 | Command                  | Definition                                                                           |
 |--------------------------|--------------------------------------------------------------------------------------|
-| `--capture-dir string`   | Directory holding the captured data. (Required)                                      | 
-| `-h, --help`             | Help for `$ vz analyze` command.                                                     |
-| `--report-file string`   | Name of report output file. (Default `stdout`)                                       |
-| `--report-format string` | The format of the report output. Valid output format is "simple". (Default "simple") |
+| `--capture-dir string`   | Directory holding the captured data. (Required)                                      |
+| `-h, --help`             | Help for the `vz analyze` command.                                                   |
+| `--report-file string`   | Name of the report output file. (Default `stdout`)                                       |
+| `--report-format string` | The format of the report. Valid output format is "simple". (Default "simple") |
 
-### Available flags
+#### Available flags
 
 These flags apply to all the commands.
 

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/_index.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Analysis Advice"
 description: ""
-weight: 2
+weight: 3
 description: Read advice based on Analysis Tools findings and reports
 draft: false
 ---


### PR DESCRIPTION
Summary of changes:
* Updated existing Analysis tool documentation to reflect the usage of new command "vz analyze" by removing old way of getting the cluster-dump (cluster-snapshot)
* Added a new document for "VZ bug-report" command referring https://confluence.oraclecorp.com/confluence/pages/viewpage.action?spaceKey=VZ&title=Verrazzano+Bug+Report+CLI
* Updated the CLI index to reflect the new command "bug-report" from available commands