### PR TITLE
VZ-6543 Remove misleading and outdated OLCNE information

### DIFF
--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -9,9 +9,6 @@ draft: false
 
 ## Install Oracle Cloud Native Environment
 Deploy Oracle Cloud Native Environment with the Kubernetes module, following instructions from [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/).
-* Use a single Kubernetes control plane node.
-* Skip the Kubernetes API load balancer ([load balancer](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#install-lb)).
-* Use private CA certificates ([private certs](https://docs.oracle.com/en/operating-systems/olcne/1.5/start/install.html#certs-private)).
 * Install a Kubernetes network load balancer implementation, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/oci.html#oci) or [MetalLB](https://docs.oracle.com/en/operating-systems/olcne/1.5/lb/metallb.html#metallb).
 * Install a Container Storage Interface Driver, such as [OCI-CCM](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/oci.html#oci) or [Gluster](https://docs.oracle.com/en/operating-systems/olcne/1.5/storage/gluster.html#gluster).
 


### PR DESCRIPTION
These bullet points in the Verrazzano OLCNE documentation are no longer needed as they are incorrect, and/or covered by the OLCNE documentation.