### PR TITLE
Documentation change for the renaming of operator.yaml in the distribution

### DIFF
--- a/content/en/docs/setup/install/installation.md
+++ b/content/en/docs/setup/install/installation.md
@@ -96,7 +96,7 @@ To install the Verrazzano platform operator:
 1. Deploy the Verrazzano platform operator.
 
     ```
-    $ kubectl apply -f {{<release_asset_url operator.yaml>}}
+    $ kubectl apply -f {{<release_asset_url verrazzano-platform-operator.yaml>}}
     ```
 
 1. Wait for the deployment to complete.

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -80,9 +80,13 @@ In order to upgrade an existing Verrazzano installation, you must first update t
    $ kubectl apply -f {{<release_asset_url verrazzano-platform-operator.yaml>}}
    ```
 
-   To update to a specific version prior to v1.4.0, where `<version>` is the desired version:
+   To update to a specific version, where `<version>` is the desired version:
 
    ```
+   # To update to version v1.4.0:
+   $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/verrazzano-platform-operator.yaml
+ 
+   # To update to a version prior to v1.4.0:
    $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/operator.yaml
    ```
 

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -77,12 +77,16 @@ In order to upgrade an existing Verrazzano installation, you must first update t
    To update to the latest version:
 
    ```
-   $ kubectl apply -f {{<release_asset_url operator.yaml>}}
+   $ kubectl apply -f {{<release_asset_url verrazzano-platform-operator.yaml>}}
    ```
 
    To update to a specific version, where `<version>` is the desired version:
 
    ```
+   # To update to version v1.4.0:
+   $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/verrazzano-platform-operator.yaml
+
+   # To update to a version prior to v1.4.0:
    $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/operator.yaml
    ```
 

--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -80,13 +80,9 @@ In order to upgrade an existing Verrazzano installation, you must first update t
    $ kubectl apply -f {{<release_asset_url verrazzano-platform-operator.yaml>}}
    ```
 
-   To update to a specific version, where `<version>` is the desired version:
+   To update to a specific version prior to v1.4.0, where `<version>` is the desired version:
 
    ```
-   # To update to version v1.4.0:
-   $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/verrazzano-platform-operator.yaml
-
-   # To update to a version prior to v1.4.0:
    $ kubectl apply -f https://github.com/verrazzano/verrazzano/releases/download/<version>/operator.yaml
    ```
 


### PR DESCRIPTION
The Verrazzano Lite distribution includes verrazzano-platform-operator.yaml, which was operator.yaml in the earlier releases. This change updates operator YAML file in the documentation.