### PR TITLE
Update download location of verrazzano release bundles for private registry setup

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -5,10 +5,10 @@
 release_version = "master"
 
 # Version number used as part of search result when downloading from Oracle Software Delivery Cloud
-download_package_version = "1.2"
+download_package_version = "1.4.0.0.0"
 
 # Full version number used as part of downloaded artifact when downloading from Oracle Software Delivery Cloud
-download_package_full_version = "1.2.0"
+download_package_full_version = "1.4.0.0.0"
 
 opensearch_docs_url = "https://opensearch.org/docs/1.2"
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -102,13 +102,13 @@ Set up a private registry using the following instructions, depending on your di
 
         b. Select the `Patches & Updates` tab.
 
-        c. In the `Patch Search` panel, click the link `Product or Family (Advanced)`.
+        c. In the `Patch Search` panel, select the link `Product or Family (Advanced)`.
 
         d. In the search bar for `Product is`, enter `Oracle Verrazzano Enterprise Container Platform`.
 
-        e. The above step populates the available releases for Verrazzano in the dropdown box `Release is`. Select the desired release(s) and click **Search**.
+        e. The previous step populates the available releases for Verrazzano in the drop-down box `Release is`. Select the desired release(s) and click **Search**.
 
-        f. A new panel with `Patch Advanced Search Results` will open listing all the patches for the release. Click the link for the desired patch, under the `Patch Name`.
+        f. A new panel with `Patch Advanced Search Results` will open listing all the patches for the release. Select the link for the desired patch, under the `Patch Name`.
 
         g. From the page providing details about the patch, click **Download**.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -100,7 +100,7 @@ Set up a private registry using the following instructions, depending on your di
 
         a. In your browser, go to [My Oracle Support](https://support.oracle.com/) and log in with your credentials.
 
-        b. Select `Patches & Updates` tab at the top of the `MY ORACLE SUPPORT` page.
+        b. Select `Patches & Updates` tab.
 
         c. In the `Patch Search` panel, click the link `Product or Family (Advanced)`.
 
@@ -108,9 +108,9 @@ Set up a private registry using the following instructions, depending on your di
 
         e. The above step populates the available releases for Verrazzano in the dropdown box `Release is`. Select the desired release(s) and click **Search**.
 
-        f. Click the link for the desired patch, under the `Patch Name` and click **Download**.
+        f. A new panel with `Patch Advanced Search Results` will open listing all the patches for the release. Click the link for the desired patch, under the `Patch Name`.
 
-        g. From the page providing details about the patch, Click **Download**.
+        g. From the page providing details about the patch, click **Download**.
 
         h. Download the ZIP file by selecting the file link.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -93,7 +93,6 @@ Set up a private registry using the following instructions, depending on your di
         g. Accept the license agreement and click **Continue**.
 
         h. Download the file:
-
         * To download the ZIP file directly, select the file link in the list.
         * To download the ZIP file using `Oracle Download Manager`, click **Download** and run the `Oracle Download Manager` executable.
 
@@ -105,11 +104,13 @@ Set up a private registry using the following instructions, depending on your di
 
         c. In the `Patch Search` panel, click the link `Product or Family (Advanced)`.
 
-        d. In the search bar for `Product is`, enter `Oracle Verrazzano Enterprise Container Platform`. From the dropdown for `Release is`, select the desired release and click **Search**.
+        d. In the search bar for `Product is`, enter `Oracle Verrazzano Enterprise Container Platform`.
 
-        e. Click the link for the desired patchset, under the `Patch Name`.
+        e. The above step populates the available releases for Verrazzano in the dropdown box `Release is`. Select the desired release(s) and click **Search**.
 
-        f. From the page providing details about the patch, Click **Download**.
+        f. Click the link for the desired patch, under the `Patch Name` and click **Download**.
+
+        g. From the page providing details about the patch, Click **Download**.
 
         h. Download the ZIP file by selecting the file link.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -106,7 +106,7 @@ Set up a private registry using the following instructions, depending on your di
 
         d. In the search bar for `Product is`, enter `Oracle Verrazzano Enterprise Container Platform`.
 
-        e. The previous step populates the available releases for Verrazzano in the drop-down box `Release is`. Select the desired release(s) and click **Search**.
+        e. The previous step populates the available releases for Verrazzano in the drop-down menu `Release is`. Select the desired release(s) and click **Search**.
 
         f. A new panel with `Patch Advanced Search Results` will open listing all the patches for the release. Select the link for the desired patch, under the `Patch Name`.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -100,7 +100,7 @@ Set up a private registry using the following instructions, depending on your di
 
         a. In your browser, go to [My Oracle Support](https://support.oracle.com/) and log in with your credentials.
 
-        b. Select `Patches & Updates` tab.
+        b. Select the `Patches & Updates` tab.
 
         c. In the `Patch Search` panel, click the link `Product or Family (Advanced)`.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -75,26 +75,43 @@ Set up a private registry using the following instructions, depending on your di
 
 ## Load the images
 
-1. Download the Verrazzano ZIP file from the Oracle Software Delivery Cloud.
+1. Download the Verrazzano ZIP file
+    * Download the Verrazzano ZIP file from the Oracle Software Delivery Cloud for major or minor releases.
 
-    a. In your browser, go to the [Oracle Software Delivery Cloud](https://edelivery.oracle.com) and log in with your credentials.
+        a. In your browser, go to the [Oracle Software Delivery Cloud](https://edelivery.oracle.com) and log in with your credentials.
 
-    b. In the drop-down menu preceding the search bar, select **All Categories**.
+        b. In the drop-down menu preceding the search bar, select **All Categories**.
 
-    c. In the search bar, enter `Verrazzano Enterprise Container Platform` and click **Search**.
+        c. In the search bar, enter `Verrazzano Enterprise Container Platform` and click **Search**.
 
-    d. Select the `DLP: Oracle Verrazzano Enterprise Edition {{<download_package_version>}}` link.  This will add it to your download queue.
+        d. Select the `REL: Oracle Verrazzano Enterprise Edition {{<download_package_version>}}` link.  This will add it to your download queue.
 
-    e. At the top of the page, select the **Continue** link.
+        e. At the top of the page, select the **Continue** link.
 
-    f. Review the Download Queue, then click **Continue**.
+        f. Review the Download Queue, then click **Continue**.
 
-    g. Accept the license agreement and click **Continue**.
+        g. Accept the license agreement and click **Continue**.
 
-    h. Download the file:
+        h. Download the file:
 
-     * To download the ZIP file directly, select the file link in the list.
-     * To download the ZIP file using `Oracle Download Manager`, click **Download** and run the `Oracle Download Manager` executable.    
+        * To download the ZIP file directly, select the file link in the list.
+        * To download the ZIP file using `Oracle Download Manager`, click **Download** and run the `Oracle Download Manager` executable.
+
+    * Download the Verrazzano ZIP file from My Oracle Support for cumulative patches.
+
+        a. In your browser, go to [My Oracle Support](https://support.oracle.com/) and log in with your credentials.
+
+        b. Select `Patches & Updates` tab at the top of the `MY ORACLE SUPPORT` page.
+
+        c. In the `Patch Search` panel, click the link `Product or Family (Advanced)`.
+
+        d. In the search bar for `Product is`, enter `Oracle Verrazzano Enterprise Container Platform`. From the dropdown for `Release is`, select the desired release and click **Search**.
+
+        e. Click the link for the desired patchset, under the `Patch Name`.
+
+        f. From the page providing details about the patch, Click **Download**.
+
+        h. Download the ZIP file by selecting the file link.
 
 2. Prepare to do the private registry installation.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -84,7 +84,7 @@ Set up a private registry using the following instructions, depending on your di
 
         c. In the search bar, enter `Verrazzano Enterprise Container Platform` and click **Search**.
 
-        d. Select the `REL: Oracle Verrazzano Enterprise Edition {{<download_package_version>}}` link.  This will add it to your download queue.
+        d. Select the `REL: Verrazzano Enterprise Edition {{<download_package_version>}}` link.  This will add it to your download queue.
 
         e. At the top of the page, select the **Continue** link.
 


### PR DESCRIPTION
This change updates the location from where the Verrazzano release bundles can be downloaded, in the documentation for setting up Private Registry.