### PR TITLE
Fix version of Verrazzano displayed in Oracle Software Delivery Cloud, in private registry setup

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -4,11 +4,11 @@
 # Used by short codes release_asset_url and release_source_url which are defined files in layouts/shortcodes
 release_version = "v1.4.0"
 
-# Version number used as part of search result when downloading from Oracle Software Delivery Cloud
+# Version number used in Verrazzano release assets. For example, 1.4.0 in verrazzano-1.4.0-linux-amd64.tar.gz
 download_package_version = "1.4.0"
 
 # Full version number used as part of downloaded artifact when downloading from Oracle Software Delivery Cloud
-download_package_full_version = "1.4.0"
+download_package_full_version = "1.4.0.0.0"
 
 opensearch_docs_url = "https://opensearch.org/docs/1.2"
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -84,7 +84,7 @@ Set up a private registry using the following instructions, depending on your di
 
         c. In the search bar, enter `Verrazzano Enterprise Container Platform` and click **Search**.
 
-        d. Select the `REL: Verrazzano Enterprise Edition {{<download_package_full_version>}}` link.  This will add it to your download queue.
+        d. Select the `REL: Verrazzano Enterprise Container Platform {{<download_package_full_version>}}` link. This will add it to your download queue.
 
         e. At the top of the page, select the **Continue** link.
 

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -84,7 +84,7 @@ Set up a private registry using the following instructions, depending on your di
 
         c. In the search bar, enter `Verrazzano Enterprise Container Platform` and click **Search**.
 
-        d. Select the `REL: Verrazzano Enterprise Edition {{<download_package_version>}}` link.  This will add it to your download queue.
+        d. Select the `REL: Verrazzano Enterprise Edition {{<download_package_full_version>}}` link.  This will add it to your download queue.
 
         e. At the top of the page, select the **Continue** link.
 


### PR DESCRIPTION
This change updates the version of Verrazzano displayed in Oracle Software Delivery Cloud, in private registry setup for release-1.4