### PR TITLE
VZ-7390 Documentation fix for enclosing true in quotes for OCI LB annotation

### DIFF
--- a/content/en/docs/customize/ociLoadBalancerIPs.md
+++ b/content/en/docs/customize/ociLoadBalancerIPs.md
@@ -99,7 +99,7 @@ spec:
             controller:
               service:
                 annotations:
-                  service.beta.kubernetes.io/oci-load-balancer-internal: true
+                  service.beta.kubernetes.io/oci-load-balancer-internal: "true"
                   service.beta.kuernetes.io/oci-load-balancer-subnet1: "ocid1.subnet.oc1.phx.aaaa..sdjxa"
 ```
 
@@ -127,7 +127,7 @@ spec:
                     name: istio-ingressgateway
                     k8s:
                       serviceAnnotations:
-                        service.beta.kubernetes.io/oci-load-balancer-internal: true
+                        service.beta.kubernetes.io/oci-load-balancer-internal: "true"
                         serivce.beta.kubernetes.io/oci-load-balancer-subnet1: "ocid1.subnet.oc1.phx.aaaa..sdjxa"
 ```
 
@@ -149,7 +149,7 @@ spec:
             controller:
               service:
                 annotations:
-                  service.beta.kubernetes.io/oci-load-balancer-internal: true
+                  service.beta.kubernetes.io/oci-load-balancer-internal: "true"
                   service.beta.kuernetes.io/oci-load-balancer-subnet1: "ocid1.subnet.oc1.phx.aaaa..sdjxa"
     istio:
       overrides:
@@ -163,6 +163,6 @@ spec:
                     name: istio-ingressgateway
                     k8s:
                       serviceAnnotations:
-                        service.beta.kubernetes.io/oci-load-balancer-internal: true
+                        service.beta.kubernetes.io/oci-load-balancer-internal: "true"
                         serivce.beta.kubernetes.io/oci-load-balancer-subnet1: "ocid1.subnet.oc1.phx.aaaa..sdjxa"
 ```


### PR DESCRIPTION
VZ-7390 The documented sample provided for customizing OCI Load Balancers [LINK](https://verrazzano.io/latest/docs/customize/ociloadbalancerips/) contains a wrong annotation value.
`service.beta.kubernetes.io/oci-load-balancer-internal: true`. Since `true` is treated as a boolean value, the webhook validation fails and the VZ CR creation fails. This PR is for fixing the documentation with the sample VZ CR having `true` values enclosed in quotes.