### PR TITLE
VZ-4505: ToDo List Instructions Don't Wait for Pod to Exist

### DIFF
--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -78,17 +78,17 @@ For more information and the source code of this application, see the [Verrazzan
    $ kubectl apply -f {{< release_source_url raw=true path=examples/todo-list/todo-list-application.yaml >}} -n todo-list
    ```
 
-1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output, or
-you can use the `kubectl wait` command. You may need to repeat the `kubectl wait` command several times before it is successful.
-   The `tododomain-adminserver` pod may take a while to be created and `Ready`.
+1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output.
+ The application is ready when the `tododomain-adminserver` pod is `Running`, and all of its containers are `Ready`. The
+`tododomain-adminserver` pod may take a while to be created.
    ```
-   $ kubectl get pods -n todo-list
-
-   # -or- #
-
-   $ kubectl wait pod \
-      --for=condition=Ready tododomain-adminserver \
-      -n todo-list
+   # This will watch for changes. Exit this command once the `tododomain-adminserver` pod is ready.
+   $ kubectl get pods -n todo-list -w
+   
+   # Sample output
+   NAME                            READY   STATUS            RESTARTS   AGE
+   ...                             ...     ...               ...        ...
+   tododomain-adminserver          4/4     Running           0          52s
    ```
 
 1. Get the generated host name for the application.

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -79,8 +79,10 @@ For more information and the source code of this application, see the [Verrazzan
    ```
 
 1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output, or
-you can use the `kubectl wait` command. You may need to repeat the `kubectl wait` command several times before it is successful.
-   The `tododomain-adminserver` pod may take a while to be created and `Ready`.
+you can use the `kubectl wait` command. The `kubectl wait` command may report an error saying `pods "tododomain-adminserver" 
+   not found` if executed before the `tododomain-adminserver` pod is created. The `tododomain-adminserver` pod may take a 
+   while to be created and `Ready`, so you may need to repeat the `kubectl wait` command several times before it is successful.
+   
    ```
    $ kubectl get pods -n todo-list
 

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -78,26 +78,29 @@ For more information and the source code of this application, see the [Verrazzan
    $ kubectl apply -f {{< release_source_url raw=true path=examples/todo-list/todo-list-application.yaml >}} -n todo-list
    ```
 
-1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output, or
-you can use the `kubectl wait` commands. The `kubectl wait` commands may report `error: no matching resources found` if executed
-before the respective pods are created. Particularly, the `tododomain-adminserver` pod may take a while to be created and `Ready`,
-so you may need to repeat the `kubectl wait` command several times before it is successful.
+1. Wait for the ToDo List application to be ready.
    
+   You can monitor its progress by listing pods and inspecting the output.
+
    ```
    $ kubectl get pods -n todo-list
+   ```
 
-   # -or- #
-
+   Alternatively, you can use the `kubectl wait` commands. The `kubectl wait` commands may report `error: no matching resources found`
+   if executed before the respective pods are created. Particularly, the `tododomain-adminserver` pod may take a while to be created
+   and `Ready`, so you may need to repeat the `kubectl wait` command several times before it is successful.
+   
+   ```
    $ kubectl wait pod \
         --for=condition=Ready \
         -l app.oam.dev/component=todo-mysql-deployment \
         -n todo-list \
-        --timeout=20m
+        --timeout=5m
    $ kubectl wait pod \
         --for=condition=Ready \
         -l weblogic.serverName=AdminServer \
         -n todo-list \
-        --timeout=20m
+        --timeout=5m
    ```
 
 1. Get the generated host name for the application.

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -78,17 +78,17 @@ For more information and the source code of this application, see the [Verrazzan
    $ kubectl apply -f {{< release_source_url raw=true path=examples/todo-list/todo-list-application.yaml >}} -n todo-list
    ```
 
-1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output.
- The application is ready when the `tododomain-adminserver` pod is `Running`, and all of its containers are `Ready`. The
-`tododomain-adminserver` pod may take a while to be created.
+1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output, or
+you can use the `kubectl wait` command. You may need to repeat the `kubectl wait` command several times before it is successful.
+   The `tododomain-adminserver` pod may take a while to be created and `Ready`.
    ```
-   # This will watch for changes. Exit this command once the `tododomain-adminserver` pod is ready.
-   $ kubectl get pods -n todo-list -w
-   
-   # Sample output
-   NAME                            READY   STATUS            RESTARTS   AGE
-   ...                             ...     ...               ...        ...
-   tododomain-adminserver          4/4     Running           0          52s
+   $ kubectl get pods -n todo-list
+
+   # -or- #
+
+   $ kubectl wait pod \
+      --for=condition=Ready tododomain-adminserver \
+      -n todo-list
    ```
 
 1. Get the generated host name for the application.

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -78,17 +78,16 @@ For more information and the source code of this application, see the [Verrazzan
    $ kubectl apply -f {{< release_source_url raw=true path=examples/todo-list/todo-list-application.yaml >}} -n todo-list
    ```
 
-1. Wait for the ToDo List application to be ready.
-   
-   You can monitor its progress by listing pods and inspecting the output.
+1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output.
 
    ```
    $ kubectl get pods -n todo-list
    ```
 
-   Alternatively, you can use the `kubectl wait` commands. The `kubectl wait` commands may report `error: no matching resources found`
-   if executed before the respective pods are created. Particularly, the `tododomain-adminserver` pod may take a while to be created
-   and `Ready`, so you may need to repeat the `kubectl wait` command several times before it is successful.
+   Alternatively, you can use the `kubectl wait` commands. However, if executed before the respective pods are created,
+   then the `kubectl wait` commands may report `error: no matching resources found`. Specifically, the `tododomain-adminserver`
+   pod may take a while to be created and `Ready`, so you may need to repeat the `kubectl wait` command several times before
+   it is successful.
    
    ```
    $ kubectl wait pod \

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -79,9 +79,9 @@ For more information and the source code of this application, see the [Verrazzan
    ```
 
 1. Wait for the ToDo List application to be ready. You can monitor its progress by listing pods and inspecting the output, or
-you can use the `kubectl wait` command. The `kubectl wait` command may report an error saying `pods "tododomain-adminserver" 
-   not found` if executed before the `tododomain-adminserver` pod is created. The `tododomain-adminserver` pod may take a 
-   while to be created and `Ready`, so you may need to repeat the `kubectl wait` command several times before it is successful.
+you can use the `kubectl wait` commands. The `kubectl wait` commands may report `error: no matching resources found` if executed
+before the respective pods are created. Particularly, the `tododomain-adminserver` pod may take a while to be created and `Ready`,
+so you may need to repeat the `kubectl wait` command several times before it is successful.
    
    ```
    $ kubectl get pods -n todo-list
@@ -89,8 +89,15 @@ you can use the `kubectl wait` command. The `kubectl wait` command may report an
    # -or- #
 
    $ kubectl wait pod \
-      --for=condition=Ready tododomain-adminserver \
-      -n todo-list
+        --for=condition=Ready \
+        -l app.oam.dev/component=todo-mysql-deployment \
+        -n todo-list \
+        --timeout=20m
+   $ kubectl wait pod \
+        --for=condition=Ready \
+        -l weblogic.serverName=AdminServer \
+        -n todo-list \
+        --timeout=20m
    ```
 
 1. Get the generated host name for the application.


### PR DESCRIPTION
This PR revises the instructions to monitor the deployed ToDo List application after the .yaml files are applied. The previous instructions have a `kubectl wait` command that errored due to the `tododomain-adminserver` pod not existing. This PR aims to improve this `kubectl wait` command and make any possible errors clear to users.