### PR TITLE
update gateway name

### DIFF
--- a/content/en/docs/applications/traits/ingress/ingress.md
+++ b/content/en/docs/applications/traits/ingress/ingress.md
@@ -34,7 +34,7 @@ In the sample configuration, the IngressTrait `hello-helidon-ingress` is set on 
 
 For example, with the sample application configuration successfully deployed, the application will be accessible with the `path` specified in the IngressTrait and the generated host name.
 ```
-$ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-appconf-gw -n hello-helidon -o jsonpath={.spec.servers[0].hosts[0]})
+$ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-gw -n hello-helidon -o jsonpath={.spec.servers[0].hosts[0]})
 $ echo $HOST
 hello-helidon-appconf.hello-helidon.11.22.33.44.nip.io
 
@@ -113,4 +113,3 @@ Use the following rules related to the host name:
 - If you provide a host name, then you have an option to provide a certificate.  If you do not provide a certificate, then Verrazzano generates one for you.
 - If you provide a certificate, then you must provide a host name.
 - If you do not provide either a host name or a certificate, then Verrazzano generates them for you.
-

--- a/content/en/docs/guides/app-deployment/application-deployment-guide.md
+++ b/content/en/docs/guides/app-deployment/application-deployment-guide.md
@@ -248,7 +248,7 @@ and enabled for Istio.
    ingress DNS name to the application's load balancer IP address.
    The generated host name is obtained by querying Kubernetes for the gateway:
    ```
-   $ kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-appconf-gw \
+   $ kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-gw \
        -n hello-helidon \
        -o jsonpath='{.spec.servers[0].hosts[0]}'
    ```
@@ -352,7 +352,7 @@ If DNS was not configured, then use the alternative commands.
 
 1.  Save the host name and IP address of the load balancer exposing the application's REST service endpoints for later.
     ```
-    $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-appconf-gw \
+    $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-gw \
           -n hello-helidon \
           -o jsonpath='{.spec.servers[0].hosts[0]}')
     $ ADDRESS=$(kubectl get service \

--- a/content/en/docs/networking/traffic/net-traffic.md
+++ b/content/en/docs/networking/traffic/net-traffic.md
@@ -216,7 +216,7 @@ items:
   kind: Gateway
   metadata:
    ...
-    name: hello-helidon-hello-helidon-appconf-gw
+    name: hello-helidon-hello-helidon-gw
     namespace: hello-helidon
   ...
   spec:
@@ -247,7 +247,7 @@ items:
     namespace: hello-helidon
   spec:
     gateways:
-    - hello-helidon-hello-helidon-appconf-gw
+    - hello-helidon-hello-helidon-gw
     hosts:
     - hello-helidon-appconf.hello-helidon.1.2.3.4.nip.io
     HTTP:

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -112,7 +112,7 @@ enabled for Istio.
 
 1.  Save the host name of the load balancer exposing the application's REST service endpoints.
     ```
-    $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-appconf-gw \
+    $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-gw \
         -n hello-helidon \
         -o jsonpath='{.spec.servers[0].hosts[0]}')
     ```

--- a/content/en/docs/samples/hello-helidon/_index.md
+++ b/content/en/docs/samples/hello-helidon/_index.md
@@ -52,7 +52,7 @@ Follow these steps to test the endpoints.
 1. Get the generated host name for the application.
 
    ```
-   $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-appconf-gw \
+   $ HOST=$(kubectl get gateways.networking.istio.io hello-helidon-hello-helidon-gw \
         -n hello-helidon \
         -o jsonpath='{.spec.servers[0].hosts[0]}')
    $ echo $HOST

--- a/content/en/docs/troubleshooting/troubleshooting-application-deployment.md
+++ b/content/en/docs/troubleshooting/troubleshooting-application-deployment.md
@@ -85,7 +85,7 @@ The following commands are examples of checking for the resources related to an 
 ```
 $ kubectl get -n hello-helidon ingresstrait hello-helidon-ingress
 $ kubectl get -n istio-system Certificate hello-helidon-hello-helidon-appconf-cert
-$ kubectl get -n hello-helidon gateway hello-helidon-hello-helidon-appconf-gw
+$ kubectl get -n hello-helidon gateway hello-helidon-hello-helidon-gw
 $ kubectl get -n hello-helidon virtualservice hello-helidon-ingress-rule-0-vs
 ```
 


### PR DESCRIPTION
When trying out the Quick Start, I found that the gateway name was changed from `hello-helidon-hello-helidon-appconf-gw` to `hello-helidon-hello-helidon-gw` and was not updated in the docs, hence this PR. However, I need to know when this change occurred. Please point me to a developer who might know. Thank you.