### PR TITLE
edit path to example files

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -92,8 +92,8 @@ enabled for Istio.
 1. Apply the `hello-helidon` resources to deploy the application.
 
    ```
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}} -n hello-helidon
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}} -n hello-helidon
+   $ kubectl apply -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-comp.yaml >}} -n hello-helidon
+   $ kubectl apply -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-app.yaml >}} -n hello-helidon
    ```
 
 1. Wait for the application to be ready.
@@ -133,8 +133,8 @@ enabled for Istio.
 1. Delete the Verrazzano application resources.
 
    ```
-   $ kubectl delete -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}}
-   $ kubectl delete -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}}
+   $ kubectl delete -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-comp.yaml >}}
+   $ kubectl delete -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-app.yaml >}}
     ```
 
 1. Delete the example namespace.


### PR DESCRIPTION
Previous path (using `ghlink`) resulted in resources that were not deleted, for example:
$ kubectl apply -f https://raw.githubusercontent.com/verrazzano/verrazzano/master/examples/hello-helidon/hello-helidon-comp.yaml -n hello-helidon
**component**.core.oam.dev/hello-helidon-component created
$kubectl delete -f https://raw.githubusercontent.com/verrazzano/verrazzano/master/examples/hello-helidon/hello-helidon-comp.yaml
Error from server (NotFound): error when deleting "https://raw.githubusercontent.com/verrazzano/verrazzano/master/examples/hello-helidon/hello-helidon-comp.yaml": **components**.core.oam.dev "hello-helidon-component" not found

Whereas, in the Hello Helidon example apps, the current path (using `release_source_url` instead) worked correctly:
$ kubectl apply -f https://raw.githubusercontent.com/verrazzano/verrazzano/v1.4.1/examples/hello-helidon/hello-helidon-comp.yaml -n hello-helidon
component.core.oam.dev/hello-helidon-component created
$ kubectl delete -f https://raw.githubusercontent.com/verrazzano/verrazzano/v1.4.1/examples/hello-helidon/hello-helidon-comp.yaml -n hello-helidon
component.core.oam.dev "hello-helidon-component" deleted

