### PR TITLE
fix QS and replace term

### DIFF
--- a/content/en/docs/monitoring/metrics/metrics.md
+++ b/content/en/docs/monitoring/metrics/metrics.md
@@ -124,7 +124,7 @@ To verify that the metrics template process was successful, follow these steps:
 1. Verify that the State of this target is `UP`.
 1. Next, use the navigation bar to access the Graph.
 1. Here, use the job name you copied to construct this expression: `{job="<job_name>"}`
-1. Use the graph to execute this expression and verify that you see application metrics appear.
+1. Use the graph to run this expression and verify that you see application metrics appear.
 
 #### Prometheus overrides
 

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -137,8 +137,8 @@ enabled for Istio.
 1. Apply the `hello-helidon` resources to deploy the application.
 
    ```
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}} -n hello-helidon
-   $ kubectl apply -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}} -n hello-helidon
+   $ kubectl apply -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-comp.yaml >}} -n hello-helidon
+   $ kubectl apply -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-app.yaml >}} -n hello-helidon
    ```
 
 1. Wait for the application to be ready.
@@ -180,8 +180,8 @@ To uninstall the Hello World Helidon example application:
 1. Delete the Verrazzano application resources.
 
    ```
-   $ kubectl delete -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-comp.yaml" >}}
-   $ kubectl delete -f {{< ghlink raw=true path="examples/hello-helidon/hello-helidon-app.yaml" >}}
+   $ kubectl delete -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-comp.yaml >}}
+   $ kubectl delete -f {{< release_source_url raw=true path=examples/hello-helidon/hello-helidon-app.yaml >}}
     ```
 
 1. Delete the example namespace.

--- a/content/en/docs/setup/install/multicluster.md
+++ b/content/en/docs/setup/install/multicluster.md
@@ -337,7 +337,7 @@ Verify that the admin cluster is collecting metrics from the managed cluster.  T
 records that contain the name of the Verrazzano cluster (labeled as `verrazzano_cluster`).
 
 You can find the Prometheus UI URL for your cluster by following the instructions for [Accessing Verrazzano]({{< relref "/docs/access/_index.md" >}}).
-Execute a query for a metric (for example, `node_disk_io_time_seconds_total`).
+Run a query for a metric (for example, `node_disk_io_time_seconds_total`).
 
 **Sample output of a Prometheus query**
 


### PR DESCRIPTION
Fixed the path to the YAML files in the Quick Start example app to use `release_source_url` instead of `ghlink`. And, replaced the term "execute" with "run".