### PR TITLE
VZ-7315: Add section to Deprecated API Migration Guide for multicluster resources

### DIFF
--- a/content/en/docs/reference/migration.md
+++ b/content/en/docs/reference/migration.md
@@ -33,15 +33,6 @@ The `install.verrazzano.io/v1alpha1` API version of Verrazzano resources is depr
 - Use `spec.components.verrazzano.overrides` instead of `spec.components.verrazzano.installArgs`.
 - Use `spec.components.authProxy.overrides` instead of `spec.components.authProxy.kubernetes`.
 
-## Multicluster
-
-Some of the multicluster wrappers APIs, which are part of `clusters.verrazzano.io/v1alpha1`, are deprecated and will be removed in Verrazzano v2.0.0.
-The APIs that will be removed are:
-
-- MultiClusterComponent - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
-- MultiClusterConfigMap - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
-- MultiClusterSecret - Should be replaced with a Kubernetes Secret and referenced in the `spec.secrets` of a MultiClusterApplicationConfiguration resource.
-
 #### Co-installing previous Verrazzano versions
 
 After installing Verrazzano version 1.4.0 or later, and not uninstalling it _before_ installing versions of Verrazzano prior to 1.4.0, will result in the following error:
@@ -55,3 +46,12 @@ To resolve this error, delete the `verrazzanos.install.verrazzano.io` Custom Res
 ```shell
 $ kubectl delete customresourcedefinition verrazzanos.install.verrazzano.io
 ```
+
+## Multicluster
+
+Some of the multicluster wrappers APIs, which are part of `clusters.verrazzano.io/v1alpha1`, are deprecated and will be removed in Verrazzano v2.0.0.
+The APIs that will be removed are:
+
+- MultiClusterComponent - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
+- MultiClusterConfigMap - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
+- MultiClusterSecret - Should be replaced with a Kubernetes Secret and referenced in the `spec.secrets` of a MultiClusterApplicationConfiguration resource.

--- a/content/en/docs/reference/migration.md
+++ b/content/en/docs/reference/migration.md
@@ -35,12 +35,12 @@ The `install.verrazzano.io/v1alpha1` API version of Verrazzano resources is depr
 
 ## Multicluster
 
-The multicluster wrappers APIs which are part of `clusters.verrazzano.io/v1alpha1` are deprecated and will be removed in Verrazzano v2.0.0.
+Some of the multicluster wrappers APIs, which are part of `clusters.verrazzano.io/v1alpha1`, are deprecated and will be removed in Verrazzano v2.0.0.
 The APIs that will be removed are:
 
-- MultiClusterComponent - should be replaced with a `core.oam/dev/v1alpha2` Component resource
-- MultiClusterConfigMap - should be replaced with a `core.oam/dev/v1alpha2` Component resource
-- MultiClusterSecret - should be replaced with a Kubernetes Secret and referenced in the `spec.secrets` of a MultiClusterApplicationConfiguration resource
+- MultiClusterComponent - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
+- MultiClusterConfigMap - Should be replaced with a `core.oam/dev/v1alpha2` Component resource.
+- MultiClusterSecret - Should be replaced with a Kubernetes Secret and referenced in the `spec.secrets` of a MultiClusterApplicationConfiguration resource.
 
 #### Co-installing previous Verrazzano versions
 

--- a/content/en/docs/reference/migration.md
+++ b/content/en/docs/reference/migration.md
@@ -33,6 +33,15 @@ The `install.verrazzano.io/v1alpha1` API version of Verrazzano resources is depr
 - Use `spec.components.verrazzano.overrides` instead of `spec.components.verrazzano.installArgs`.
 - Use `spec.components.authProxy.overrides` instead of `spec.components.authProxy.kubernetes`.
 
+## Multicluster
+
+The multicluster wrappers APIs which are part of `clusters.verrazzano.io/v1alpha1` are deprecated and will be removed in Verrazzano v2.0.0.
+The APIs that will be removed are:
+
+- MultiClusterComponent - should be replaced with a `core.oam/dev/v1alpha2` Component resource
+- MultiClusterConfigMap - should be replaced with a `core.oam/dev/v1alpha2` Component resource
+- MultiClusterSecret - should be replaced with a Kubernetes Secret and referenced in the `spec.secrets` of a MultiClusterApplicationConfiguration resource
+
 #### Co-installing previous Verrazzano versions
 
 After installing Verrazzano version 1.4.0 or later, and not uninstalling it _before_ installing versions of Verrazzano prior to 1.4.0, will result in the following error:


### PR DESCRIPTION
This pull request adds a Multicluster section to the Deprecated API Migration Guide for APIs that will be removed in v2.0.0.