### PR TITLE
Update kubectl get pods -n verrazzano-system output

### DIFF
--- a/content/en/docs/setup/install/installation.md
+++ b/content/en/docs/setup/install/installation.md
@@ -217,20 +217,24 @@ Verrazzano installs multiple objects in multiple namespaces. In the `verrazzano-
 ```
 $ kubectl get pods -n verrazzano-system
 
-# Sample output
-coherence-operator-dcfb446df-24djp                 1/1     Running   1          49m
-fluentd-h65xf                                      2/2     Running   1          45m
-oam-kubernetes-runtime-6645df49cd-6q96c            1/1     Running   0          49m
-verrazzano-application-operator-85ffd7f77b-rhwk7   1/1     Running   0          48m
-verrazzano-authproxy-58db5b9484-nhnql              2/2     Running   0          45m
-verrazzano-console-5dbdc579bd-hm4rh                2/2     Running   0          45m
-verrazzano-monitoring-operator-599654889d-lbb4z    1/1     Running   0          45m
-verrazzano-operator-7b6fd64dd5-8j9h8               1/1     Running   0          45m
-vmi-system-os-master-0                             2/2     Running   0          45m
-vmi-system-grafana-5558d65b46-pxg78                2/2     Running   0          45m
-vmi-system-kiali-5949966fb8-465s8                  2/2     Running   0          48m
-vmi-system-opensearchDashboards-86b894d8f6-q4vb5   2/2     Running   0          45m
-weblogic-operator-646756c75c-hgz6j                 2/2     Running   0          49m
+# Sample output for a dev profile install
+NAME                                                       READY   STATUS    RESTARTS   AGE
+coherence-operator-d5565cd5d-dkm95                         1/1     Running   0          9m49s
+fluentd-sgtcg                                              2/2     Running   0          2m46s
+oam-kubernetes-runtime-665ff44c8-ldbqv                     1/1     Running   0          11m
+verrazzano-application-operator-9f87f7897-25crr            1/1     Running   0          9m37s
+verrazzano-application-operator-webhook-5bd7ccbb45-wp874   1/1     Running   0          9m37s
+verrazzano-authproxy-66767cdfc5-lsc22                      3/3     Running   0          8m31s
+verrazzano-cluster-operator-994fb6c7d-29pd7                1/1     Running   0          9m41s
+verrazzano-cluster-operator-webhook-85b85f89f4-25jgj       1/1     Running   0          9m41s
+verrazzano-console-7d999bf7-6nncm                          2/2     Running   0          8m9s
+verrazzano-monitoring-operator-754c897d65-jfmb9            2/2     Running   0          8m35s
+vmi-system-es-master-0                                     2/2     Running   0          7m59s
+vmi-system-grafana-6966f9965d-cm5pz                        3/3     Running   0          7m58s
+vmi-system-kiali-5bcfb7f775-9cc5h                          2/2     Running   0          8m28s
+vmi-system-osd-6c974854df-klgpv                            2/2     Running   0          6m2s
+weblogic-operator-c4f766c7c-knmpx                          2/2     Running   0          9m33s
+weblogic-operator-webhook-547b9756f4-454rq                 1/1     Running   0          9m33s
 ```
 </div>
 {{< /clipboard >}}


### PR DESCRIPTION
This PR updates the kubectl get pods -n verrazzano-system output shown in the install guide.