### PR TITLE
Fix the Verrazzano version in private registry setup page for full distribution

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,7 +8,8 @@ release_version = "v1.4.3"
 download_package_version = "1.4.3"
 
 # Full version number used as part of downloaded artifact when downloading from Oracle Software Delivery Cloud
-download_package_full_version = "1.4.3.0.0"
+# Do not change this value for a patch release
+download_package_full_version = "1.4.0.0.0"
 
 opensearch_docs_url = "https://opensearch.org/docs/1.2"
 


### PR DESCRIPTION
Updated the Verrazzano version to 1.4.0.0.0 in private registry setup page for full distribution.