### PR TITLE
update ingress component name

### DIFF
--- a/content/en/docs/customize/ingress.md
+++ b/content/en/docs/customize/ingress.md
@@ -21,7 +21,7 @@ metadata:
 spec:
   profile: prod
   components:
-    ingress:
+    ingressNGINX:
       type: LoadBalancer
       overrides:
       - values:

--- a/content/en/docs/customize/ociLoadBalancerIPs.md
+++ b/content/en/docs/customize/ociLoadBalancerIPs.md
@@ -40,7 +40,7 @@ metadata:
 spec:
   profile: dev
   components:
-    ingress:
+    ingressNGINX:
       type: LoadBalancer
       overrides:
         - values:
@@ -97,7 +97,7 @@ metadata:
 spec:
   profile: dev
   components:
-    ingress:
+    ingressNGINX:
       type: LoadBalancer
       overrides:
         - values:
@@ -150,7 +150,7 @@ metadata:
 spec:
   profile: dev
   components:
-    ingress:
+    ingressNGINX:
       type: LoadBalancer
       overrides:
         - values:


### PR DESCRIPTION
Update ingress component name to ingressNGINX, as per JIRA [VZ-8505](https://jira.oraclecorp.com/jira/browse/VZ-8505) Examples in customize oci Loadbalancer ingress compoment name should be ingressNGNX