### PR TITLE
Update-doc-for-VZ-3286

### DIFF
--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -110,7 +110,7 @@ because they will not need to pull the images again.
 </div>
 {{< /clipboard >}}
 
-**NOTE**: When using a private registry or experience rate-limiting, refer to the [Kind documentation](https://kind.sigs.k8s.io/docs/user/private-registries/). 
+**NOTE**: When using a private container registry or experiencing rate-limiting of container image pulls, refer to the [Kind documentation](https://kind.sigs.k8s.io/docs/user/private-registries/).
 
 ## Install and configure MetalLB
 
@@ -130,11 +130,14 @@ To install MetalLB:
 </div>
 {{< /clipboard >}}
 
-Wait for MetalLB to be ready:
+Wait for MetalLB to be `READY` `1/1` and `STATUS` `Running`:
 {{< clipboard >}}
 <div class="highlight">
 
-    $ kubectl get all -n metallb-system
+    $ kubectl get pods -n metallb-system -L app=metallb
+    NAME                         READY   STATUS    RESTARTS       AGE   APP=METALLB
+    controller-d9d8c78b6-hhplg   1/1     Running   1 (3d4h ago)   9d    
+    speaker-4lqpg                1/1     Running   1 (3d4h ago)   9d
 
 </div>
 {{< /clipboard >}}

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -110,6 +110,7 @@ because they will not need to pull the images again.
 </div>
 {{< /clipboard >}}
 
+**NOTE**: When using a private registry or experience rate-limiting, refer to the [Kind documentation](https://kind.sigs.k8s.io/docs/user/private-registries/). 
 
 ## Install and configure MetalLB
 
@@ -125,6 +126,15 @@ To install MetalLB:
         -n metallb-system memberlist \
         --from-literal=secretkey="$(openssl rand -base64 128)"
     $ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/metallb.yaml
+
+</div>
+{{< /clipboard >}}
+
+Wait for MetalLB to be ready:
+{{< clipboard >}}
+<div class="highlight">
+
+    $ kubectl get all -n metallb-system
 
 </div>
 {{< /clipboard >}}

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -130,7 +130,7 @@ To install MetalLB:
 </div>
 {{< /clipboard >}}
 
-Wait for MetalLB to be `READY` `1/1` and `STATUS` `Running`:
+Wait for MetalLB to be ready, as shown:
 {{< clipboard >}}
 <div class="highlight">
 


### PR DESCRIPTION
Enhance Kind docs as per [VZ-3286](https://jira.oraclecorp.com/jira/browse/VZ-3286) Documentation for kind should describe mounting docker logins