### PR TITLE
Fix Alertmanager component spelling

### DIFF
--- a/content/en/docs/setup/prereqs.md
+++ b/content/en/docs/setup/prereqs.md
@@ -62,7 +62,7 @@ component, its version, and a brief description.
 
 | Component                    | Version      | Description                                                                              |
 |------------------------------|--------------|------------------------------------------------------------------------------------------|
-| alert-manager                | 0.24.0       | Handles alerts sent by client applications, such as the Prometheus server.               |
+| Alertmanager                | 0.24.0       | Handles alerts sent by client applications, such as the Prometheus server.               |
 | Argo CD                      | 2.5.3        | A declarative, GitOps continuous delivery tool for Kubernetes.                           |
 | cert-manager                 | 1.9.1        | Automates the management and issuance of TLS certificates.                               |
 | Coherence Operator           | 3.2.9        | Assists with deploying and managing Coherence clusters.                                  |


### PR DESCRIPTION
As per [VZ-5225](https://jira.oraclecorp.com/jira/browse/VZ-5225) Update public documentation for Alertmanager