### PR TITLE
Transparent nav bar can be disabled

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -61,3 +61,6 @@ $lead-font-weight: 400 !default;
 
 // Custom CSS for homepage
 
+.td-navbar .navbar-brand__name {
+  display: none;
+}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,35 +1,63 @@
-{{ $cover := .HasShortcode "blocks/cover" }}
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
-        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span>
-	</a>
-	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
-		<ul class="navbar-nav mt-2 mt-lg-0">
-			{{ $p := . }}
-			{{ range .Site.Menus.main }}
-			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
-				{{ with .Page }}
-				{{ $active = or $active ( $.IsDescendant .)  }}
-				{{ end }}
-				{{ $url := urls.Parse .URL }}
-				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
-			</li>
-			{{ end }}
-			{{ if not .IsHome }}
-			{{ if  .Site.Params.versions }}
-				<li class="nav-item dropdown d-none d-lg-block">
-					{{ partial "navbar-version-selector.html" . }}
-				</li>
-			{{ end }}
-			{{ if  (gt (len .Site.Home.Translations) 0) }}
-			<li class="nav-item dropdown d-none d-lg-block">
-				{{ partial "navbar-lang-selector.html" . }}
-			</li>
-			{{ end }}
-			{{ end }}
-		</ul>
-	</div>
-	<div class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
+{{ $cover := and
+    (.HasShortcode "blocks/cover")
+    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
+-}}
+
+<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }} flex-column flex-md-row td-navbar">
+  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+    {{- /**/ -}}
+    <span class="navbar-brand__logo navbar-logo">
+	  {{ if ne .Site.Params.ui.navbar_logo false}}
+	    {{ with resources.Get "icons/logo.svg" }}
+		  {{ ( . | minify).Content | safeHTML }}
+		{{ end -}}
+	  {{ end -}}
+	</span>
+	{{- /**/ -}}
+	<span class="navbar-brand__name">
+      {{- .Site.Title -}}
+    </span>
+	{{- /**/ -}}
+  </a>
+  <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+    <ul class="navbar-nav mt-2 mt-lg-0">
+      {{ $p := . -}}
+	  {{ range .Site.Menus.main -}}
+  	  <li class="nav-item mr-4 mb-2 mb-lg-0">
+		{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+		{{ with .Page }}{{ $active = or $active ( $.IsDescendant .)  }}{{ end -}}
+		{{ $pre := .Pre -}}
+		{{ $post := .Post -}}
+		{{ $url := urls.Parse .URL -}}
+		{{ $baseurl := urls.Parse $.Site.Params.Baseurl -}}
+		<a {{/**/ -}}
+		  class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+		  href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"
+		  {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
+		>
+		    {{- with .Pre }}{{ $pre }}{{ end -}}
+		    <span {{- if $active }} class="active" {{- end }}>
+              {{- .Name -}}
+            </span>
+		    {{- with .Post }}{{ $post }}{{ end -}}
+		</a>
+	  </li>
+      {{ end -}}
+	  {{ if not .IsHome }}
+	    {{ if  .Site.Params.versions }}
+	    <li class="nav-item dropdown mr-4 d-none d-lg-block">
+          {{ partial "navbar-version-selector.html" . }}
+	    </li>
+	    {{ end -}}
+	    {{ if  (gt (len .Site.Home.Translations) 0) }}
+	    <li class="nav-item dropdown mr-4 d-none d-lg-block">
+	      {{ partial "navbar-lang-selector.html" . }}
+	    </li>
+	    {{ end -}}
+	  {{ end -}}
+	</ul>
+  </div>
+  <div class="navbar-nav d-none d-lg-block">
+	{{ partial "search-input.html" . }}
+  </div>
 </nav>

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -26,7 +26,7 @@
 }
 </style>
 {{ end }}
-<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover td-overlay td-overlay--dark -bg-{{ $col_id }}">
+<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }}{{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover{{ end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
   <div class="container td-overlay__inner">
     <div class="row">
       <div class="col-12">


### PR DESCRIPTION
This PR merges the upstream changes to the Docsy theme to allow the navbar to be disabled on the Verrazzano homepage
The homepage now looks like the following:
![Screenshot 2023-03-15 at 2 32 09 PM](https://user-images.githubusercontent.com/31927916/225408437-981fd8b5-0c51-42e6-9525-62eab2f28f25.png)
