### PR TITLE
VZ-9061 Backup and Restore documentation changes

### DIFF
--- a/content/en/docs/applications/_index.md
+++ b/content/en/docs/applications/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Applications"
 description: "Develop applications with Verrazzano"
-weight: 7
+weight: 8
 draft: false
 ---
 

--- a/content/en/docs/backup/_index.md
+++ b/content/en/docs/backup/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Back up and Restore"
+title: "Back Up and Restore"
 description: "Learn how to back up and restore Verrazzano"
 weight: 7
 draft: false

--- a/content/en/docs/backup/_index.md
+++ b/content/en/docs/backup/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Backup and Restore"
+title: "Back up and Restore"
 description: "Learn how to back up and restore Verrazzano"
 weight: 7
 draft: false

--- a/content/en/docs/backup/_index.md
+++ b/content/en/docs/backup/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Back Up and Restore"
+title: "Backup and Restore"
 description: "Learn how to back up and restore Verrazzano"
-weight: 2
+weight: 7
 draft: false
 ---
 
 The Verrazzano platform comprises a comprehensive set of open source components, linked together to provide a modern, reliable, and secure platform to deploy cloud native applications.
-These documents will help you back up and restore data and configurations in Keycloak, OpenSearch, and Rancher.
+These documents will help you back up and restore data and configurations in Argo CD, Keycloak, OpenSearch, and Rancher.
 
 The backup procedures are independent and you can invoke them in the order of your choice. For most of the backup functionality, these procedures rely on an object store as the back end, such as OCI object store.

--- a/content/en/docs/backup/_index.md
+++ b/content/en/docs/backup/_index.md
@@ -8,4 +8,4 @@ draft: false
 The Verrazzano platform comprises a comprehensive set of open source components, linked together to provide a modern, reliable, and secure platform to deploy cloud native applications.
 These documents will help you back up and restore data and configurations in Argo CD, Keycloak, OpenSearch, and Rancher.
 
-The backup procedures are independent and you can invoke them in the order of your choice. For most of the backup functionality, these procedures rely on an object store as the back end, such as OCI object store.
+The backup procedures are independent and you can invoke them in the order of your choice. For most of the backup functionality, these procedures rely on an object store as the back end, such as an OCI object store.

--- a/content/en/docs/backup/argocd.md
+++ b/content/en/docs/backup/argocd.md
@@ -1,7 +1,7 @@
 ---
-title: "Argo CD Backup and Restore"
+title: "Argo CD"
 description: "Back up and restore Argo CD"
-linkTitle: Argo CD Backup and Restore
+linkTitle: Argo CD
 weight: 2
 draft: false
 ---
@@ -195,7 +195,7 @@ created by the original cluster’s backup are automatically synced to the new c
 be able to access the backup from the original cluster on the new cluster. It is recommended to configure the
 `BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to `ReadOnly` in the
 `BackupStorageLocation` spec. This ensures that the backup in the object store is not modified from the new cluster. For
-more information, see 
+more information, see
 [Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the
 Velero documentation.
 

--- a/content/en/docs/backup/argocd.md
+++ b/content/en/docs/backup/argocd.md
@@ -189,13 +189,13 @@ To initiate an Argo CD restore operation, first delete the existing Argo CD runn
 Make sure that the data you are deleting is not needed. The restore operation will only restore data from the
 specified backup, and any additional data since that backup will be destroyed by the deletion.
 
-**NOTE**: If you are restoring Argo CD to a different cluster, make sure you have created a Velero
-`BackupStorageLocation` resource in the new cluster pointing to the same backup storage location configured in the
-original cluster. Velero resources created by the original cluster’s backup will be automatically synced to the new
-cluster. Once the sync occurs, you will be able to access the backup from original cluster on the new cluster. It's
-recommended to configure the `BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to
-`ReadOnly` in the `BackupStorageLocation` spec. This will make sure that the backup is not deleted from the object store
-by mistake during the restore. For more information, see 
+If you restore Argo CD to a different cluster, create a Velero `BackupStorageLocation` resource in the new cluster that
+points to the same backup storage location configured in the original cluster. This ensures that the Velero resources
+created by the original cluster’s backup are automatically synced to the new cluster. Once the sync completes, you will
+be able to access the backup from the original cluster on the new cluster. It is recommended to configure the
+`BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to `ReadOnly` in the
+`BackupStorageLocation` spec. This ensures that the backup in the object store is not modified from the new cluster. For
+more information, see 
 [Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the
 Velero documentation.
 

--- a/content/en/docs/backup/argocd.md
+++ b/content/en/docs/backup/argocd.md
@@ -94,7 +94,7 @@ velero-5ff8766fd4-xbn4z   1/1     Running   0          21h
 {{< /clipboard >}}
 
 5. Create a `BackupStorageLocation` resource, which the backup component will reference for subsequent backups. See the following `BackupStorageLocation` example, which uses Oracle Cloud Object Storage.
-   For more information, see [Backup Storage Location](https://velero.io/docs/v1.8/api-types/backupstoragelocation/#backup-storage-location) in the Velero documentation.
+   For more information, see [Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the Velero documentation.
 {{< clipboard >}}
 
   ```yaml
@@ -127,11 +127,11 @@ If you created applications with resources running in different namespaces, othe
   - Take a backup of all the namespaces where the application is running by specifying the namespaces as a list.
   - Take a backup of only the `argocd` namespace, create all the namespaces of different applications, and then restore from the backup.
 
-The following example shows a sample Velero `Backup` [API](https://velero.io/docs/v1.8/api-types/backup/) resource that you can create to initiate an Argo CD backup.
+The following example shows a sample Velero `Backup` [API](https://velero.io/docs/v1.9/api-types/backup/) resource that you can create to initiate an Argo CD backup.
 {{< clipboard >}}
 
 ```yaml
-$ kubectl apply -f - <<EOF
+  $ kubectl apply -f - <<EOF
   apiVersion: velero.io/v1
   kind: Backup
   metadata:
@@ -156,7 +156,7 @@ The preceding example backs up the Argo CD components:
 
 ```shell
 # To display the status of the backup, run the following command
-$ kubectl get backup -n verrazzano-backup verrazzano-argocd-backup -o yaml
+$ kubectl get backup.velero.io -n verrazzano-backup verrazzano-argocd-backup -o yaml
 ```
 ```
 # Sample output showing just the status portion of the backup
@@ -178,7 +178,7 @@ status:
 
 ### Argo CD scheduled backups
 
-Velero supports a `Schedule` [API](https://velero.io/docs/v1.8/api-types/schedule/)
+Velero supports a `Schedule` [API](https://velero.io/docs/v1.9/api-types/schedule/)
 that is a repeatable request that is sent to the Velero server to perform a backup for a given cron notation.
 After the `Schedule` object is created, the Velero server will start the backup process.
 Then, it will wait for the next valid point in the given cron expression and run the backup process on a repeating basis.
@@ -188,6 +188,17 @@ Then, it will wait for the next valid point in the given cron expression and run
 To initiate an Argo CD restore operation, first delete the existing Argo CD running on the system and all related data.
 Make sure that the data you are deleting is not needed. The restore operation will only restore data from the
 specified backup, and any additional data since that backup will be destroyed by the deletion.
+
+**NOTE**: If you are restoring Argo CD to a different cluster, make sure you have created a Velero
+`BackupStorageLocation` resource in the new cluster pointing to the same backup storage location configured in the
+original cluster. Velero resources created by the original cluster’s backup will be automatically synced to the new
+cluster. Once the sync occurs, you will be able to access the backup from original cluster on the new cluster. It's
+recommended to configure the `BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to
+`ReadOnly` in the `BackupStorageLocation` spec. This will make sure that the backup is not deleted from the object store
+by mistake during the restore. For more information, see 
+[Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the
+Velero documentation.
+
 
 1. Delete the Argo CD components and the namespace.
 {{< clipboard >}}
@@ -200,7 +211,7 @@ $ kubectl delete ns argocd
  ```
 {{< /clipboard >}}
 
-2. To perform an Argo CD restore operation, you can invoke the following example Velero `Restore` [API](https://velero.io/docs/v1.8/api-types/restore/) object.
+2. To perform an Argo CD restore operation, you can invoke the following example Velero `Restore` [API](https://velero.io/docs/v1.9/api-types/restore/) object.
 <br><br>
 **NOTE**: For Argo CD, `includedNamespaces` should list all the namespaces across which the applications are deployed.
 <br>

--- a/content/en/docs/backup/keycloak.md
+++ b/content/en/docs/backup/keycloak.md
@@ -1,7 +1,7 @@
 ---
-title: "Keycloak Backup and Restore"
+title: "Keycloak"
 description: "Back up and restore Keycloak data"
-linkTitle: Keycloak Backup and Restore
+linkTitle: Keycloak
 weight: 2
 draft: false
 ---
@@ -240,5 +240,5 @@ Then, restart the `fluentd` pods in the new cluster to use the original cluster 
 ```
 $ kubectl delete pod -l app=fluentd -n verrazzano-system
 ```
-         
+
 {{< /clipboard >}}

--- a/content/en/docs/backup/keycloak.md
+++ b/content/en/docs/backup/keycloak.md
@@ -229,4 +229,16 @@ kubectl scale sts -n keycloak keycloak --replicas=0
 kubectl scale sts -n keycloak keycloak --replicas=${KEYCLOAK_REPLICAS}
 kubectl wait -n keycloak --for=condition=ready pod -l app.kubernetes.io/instance=keycloak -timeout=600s
 ```
+**NOTE**:  If you are restoring the Keycloak on a different cluster, then make sure that the following secrets in the
+`verrazzano-system` namespace are updated in the new cluster with the corresponding values from the
+original cluster:
+- verrazzano
+- verrazzano-es-internal
+- verrazzano-prom-internal
+
+Also, restart the `fluentd` pods in the new cluster to use the original cluster password to connect to OpenSearch.
+```
+$ kubectl delete pod -l app=fluentd -n verrazzano-system
+```
+         
 {{< /clipboard >}}

--- a/content/en/docs/backup/keycloak.md
+++ b/content/en/docs/backup/keycloak.md
@@ -236,7 +236,7 @@ original cluster:
 - verrazzano-es-internal
 - verrazzano-prom-internal
 
-Also, restart the `fluentd` pods in the new cluster to use the original cluster password to connect to OpenSearch.
+Then, restart the `fluentd` pods in the new cluster to use the original cluster password to connect to OpenSearch.
 ```
 $ kubectl delete pod -l app=fluentd -n verrazzano-system
 ```

--- a/content/en/docs/backup/opensearch.md
+++ b/content/en/docs/backup/opensearch.md
@@ -1,7 +1,7 @@
 ---
-title: "OpenSearch Backup and Restore"
+title: "OpenSearch"
 description: "Back up and restore OpenSearch"
-linkTitle: OpenSearch Backup and Restore
+linkTitle: OpenSearch
 weight: 2
 draft: false
 ---

--- a/content/en/docs/backup/opensearch.md
+++ b/content/en/docs/backup/opensearch.md
@@ -51,7 +51,7 @@ To back up or restore OpenSearch, you must first enable Velero.
         components:    
           velero:
             enabled: true
-    EOF
+EOF
   ```
 {{< /clipboard >}}
 
@@ -94,7 +94,7 @@ velero-5ff8766fd4-xbn4z   1/1     Running   0          21h
 {{< /clipboard >}}
 
 5. Create a `BackupStorageLocation` resource, which the backup component will reference for subsequent backups. See the following `BackupStorageLocation` example.
-   For more information, see [Backup Storage Location](https://velero.io/docs/v1.8/api-types/backupstoragelocation/) in the Velero documentation.
+   For more information, see [Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/) in the Velero documentation.
 {{< clipboard >}}
 
   ```yaml
@@ -116,7 +116,7 @@ velero-5ff8766fd4-xbn4z   1/1     Running   0          21h
        region: us-phoenix-1
        s3ForcePathStyle: "true"
        s3Url: https://mytenancy.compat.objectstorage.us-phoenix-1.oraclecloud.com
-   EOF
+EOF
   ```
 {{< /clipboard >}}
 ## OpenSearch backup Using Velero
@@ -125,11 +125,11 @@ For OpenSearch, Verrazzano provides a custom hook that you can use along with Ve
 Due to the nature of transient data handled by OpenSearch, the hook invokes the OpenSearch snapshot APIs to back up data streams appropriately,
 thereby ensuring that there is no loss of data and avoids data corruption as well.
 
-The following example shows a sample Velero `Backup` [API](https://velero.io/docs/v1.8/api-types/backup/) resource that you can create to initiate an OpenSearch backup.
+The following example shows a sample Velero `Backup` [API](https://velero.io/docs/v1.9/api-types/backup/) resource that you can create to initiate an OpenSearch backup.
 {{< clipboard >}}
 
 ```yaml
-$ kubectl apply -f - <<EOF
+  $ kubectl apply -f - <<EOF
   apiVersion: velero.io/v1
   kind: Backup
   metadata:
@@ -197,7 +197,7 @@ $ kubectl exec -it vmi-system-es-master-0 -n verrazzano-system -- cat /tmp/<log-
 
 ### OpenSearch scheduled backups
 
-Velero supports a `Schedule` [API](https://velero.io/docs/v1.8/api-types/schedule/)
+Velero supports a `Schedule` [API](https://velero.io/docs/v1.9/api-types/schedule/)
 that is a repeatable request that is sent to the Velero server to perform a backup for a given cron notation.
 After the `Schedule` object is created, the Velero server will start the backup process.
 Then, it will wait for the next valid point in the given cron expression and run the backup process on a repeating basis.
@@ -209,6 +209,16 @@ Then, it will wait for the next valid point in the given cron expression and run
 For OpenSearch, Verrazzano provides a custom hook that you can use along with Velero to perform a restore operation.
 Due to the nature of transient data handled by OpenSearch, the hook invokes OpenSearch snapshot APIs to restore data streams appropriately,
 thereby ensuring there is no loss of data and avoids data corruption as well.
+
+**NOTE**: If you are restoring OpenSearch to a different cluster, make sure you have created a Velero
+`BackupStorageLocation` resource in the new cluster pointing to the same backup storage location configured in the
+original cluster. Velero resources created by the original cluster’s backup will be automatically synced to the new
+cluster. Once the sync occurs, you will be able to access the backup from original cluster on the new cluster. It's
+recommended to configure the `BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to
+`ReadOnly` in the `BackupStorageLocation` spec. This will make sure that the backup is not deleted from the object store
+by mistake during the restore. For more information, see
+[Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the
+Velero documentation.
 
 To initiate an OpenSearch restore operation, first delete the existing OpenSearch cluster running on the system and all related data.
 
@@ -225,48 +235,49 @@ To initiate an OpenSearch restore operation, first delete the existing OpenSearc
  ```shell
 # These are sample commands to demonstrate the OpenSearch restore process
 $ kubectl delete sts -n verrazzano-system -l verrazzano-component=opensearch
-$ kubectl delete deploy -n verrazzano-system -l verrazzano-component=opensearch    $ kubectl delete pvc -n verrazzano-system -l verrazzano-component=opensearch
+$ kubectl delete deploy -n verrazzano-system -l verrazzano-component=opensearch
+$ kubectl delete pvc -n verrazzano-system -l verrazzano-component=opensearch
  ```
 {{< /clipboard >}}
 
-3. To perform an OpenSearch restore operation, you can invoke the following example Velero `Restore` [API](https://velero.io/docs/v1.8/api-types/restore/) object.
+3. To perform an OpenSearch restore operation, you can invoke the following example Velero `Restore` [API](https://velero.io/docs/v1.9/api-types/restore/) object.
 {{< clipboard >}}
  ```yaml
-  $ kubectl apply -f - <<EOF
+   $ kubectl apply -f - <<EOF
    apiVersion: velero.io/v1
-    kind: Restore
+   kind: Restore
    metadata:
-      name: verrazzano-opensearch-restore
+     name: verrazzano-opensearch-restore
      namespace: verrazzano-backup
    spec:
      backupName: verrazzano-opensearch-backup
      includedNamespaces:
        - verrazzano-system
-      labelSelector:
-        matchLabels:
-          verrazzano-component: opensearch
-      restorePVs: false
-      hooks:
-        resources:
-         - name: opensearch-test
-           includedNamespaces:
-             - verrazzano-system       
-           labelSelector:
-              matchLabels:            
-               statefulset.kubernetes.io/pod-name: vmi-system-es-master-0
-           postHooks:
-             - exec:
-                 container: es-master
-                 command:
-                    - /usr/share/opensearch/bin/verrazzano-backup-hook
-                    - -operation
-                    - restore
-                    - -velero-backup-name
-                    - verrazzano-opensearch-backup
-                 waitTimeout: 30m
-                 execTimeout: 30m
-                  onError: Fail
-  EOF
+     labelSelector:
+       matchLabels:
+         verrazzano-component: opensearch
+     restorePVs: false
+     hooks:
+       resources:
+       - name: opensearch-test
+         includedNamespaces:
+         - verrazzano-system       
+         labelSelector:
+           matchLabels:            
+             statefulset.kubernetes.io/pod-name: vmi-system-es-master-0
+         postHooks:
+         - exec:
+             container: es-master
+             command:
+             - /usr/share/opensearch/bin/verrazzano-backup-hook
+             - -operation
+             - restore
+             - -velero-backup-name
+             - verrazzano-opensearch-backup
+             waitTimeout: 30m
+             execTimeout: 30m
+             onError: Fail
+EOF
    ```
 {{< /clipboard >}}
 

--- a/content/en/docs/backup/opensearch.md
+++ b/content/en/docs/backup/opensearch.md
@@ -210,13 +210,13 @@ For OpenSearch, Verrazzano provides a custom hook that you can use along with Ve
 Due to the nature of transient data handled by OpenSearch, the hook invokes OpenSearch snapshot APIs to restore data streams appropriately,
 thereby ensuring there is no loss of data and avoids data corruption as well.
 
-**NOTE**: If you are restoring OpenSearch to a different cluster, make sure you have created a Velero
-`BackupStorageLocation` resource in the new cluster pointing to the same backup storage location configured in the
-original cluster. Velero resources created by the original cluster’s backup will be automatically synced to the new
-cluster. Once the sync occurs, you will be able to access the backup from original cluster on the new cluster. It's
-recommended to configure the `BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to
-`ReadOnly` in the `BackupStorageLocation` spec. This will make sure that the backup is not deleted from the object store
-by mistake during the restore. For more information, see
+If you restore OpenSearch to a different cluster, create a Velero `BackupStorageLocation` resource in the new cluster
+that points to the same backup storage location configured in the original cluster. This ensures that the Velero
+resources created by the original cluster’s backup are automatically synced to the new cluster. Once the sync completes,
+you will be able to access the backup from the original cluster on the new cluster. It is recommended to configure the
+`BackupStorageLocation` on the new cluster as read-only by setting `accessMode` to
+`ReadOnly` in the `BackupStorageLocation` spec. This ensures that the backup in the object store  is not modified from
+the new cluster. For more information, see
 [Backup Storage Location](https://velero.io/docs/v1.9/api-types/backupstoragelocation/#backup-storage-location) in the
 Velero documentation.
 

--- a/content/en/docs/backup/rancher.md
+++ b/content/en/docs/backup/rancher.md
@@ -47,7 +47,7 @@ $ kubectl apply -f -<<EOF
      components:    
       rancherBackup:
          enabled: true
-    EOF
+EOF
   ```
 {{< /clipboard >}}
 
@@ -101,7 +101,7 @@ The rancher-backup Operator creates the backup file, in `*.tar.gz` format, on th
           region: <region name where bucket exists>
           endpoint: <object store endpoint configuration>
       resourceSetName: rancher-resource-set
-  EOF
+EOF
   ```
 {{< /clipboard >}}
 
@@ -127,7 +127,7 @@ The following is an example:
           region: us-phoenix-1
           endpoint: mytenancy.compat.objectstorage.us-phoenix-1.oraclecloud.com
       resourceSetName: rancher-resource-set
-    EOF
+EOF
    ```
 {{< /clipboard >}}
 
@@ -173,7 +173,7 @@ Restoring Rancher is done by creating a custom resource that indicates to `ranch
           folder: rancher-backup
           region: us-phoenix-1
           endpoint: mytenancy.compat.objectstorage.us-phoenix-1.oraclecloud.com
-  EOF
+EOF
    ```
 {{< /clipboard >}}
    The rancher-backup Operator scales down the Rancher deployment during the restore operation and scales it back up after the restoration completes.

--- a/content/en/docs/backup/rancher.md
+++ b/content/en/docs/backup/rancher.md
@@ -1,7 +1,7 @@
 ---
-title: "Rancher Backup and Restore"
+title: "Rancher"
 description: "Back up and restore Rancher"
-linkTitle: Rancher Backup and Restore
+linkTitle: Rancher
 weight: 2
 draft: false
 ---

--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: "Answers to commonly asked questions and known issues"
-weight: 11
+weight: 12
 draft: false
 ---
 

--- a/content/en/docs/guides/_index.md
+++ b/content/en/docs/guides/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Guides"
 description: "Guides for common tasks with Verrazzano"
-weight: 11
+weight: 13
 draft: false
 ---

--- a/content/en/docs/guides/ha/prod-upgrade.md
+++ b/content/en/docs/guides/ha/prod-upgrade.md
@@ -10,7 +10,7 @@ The exact steps required to upgrade a Verrazzano environment to achieve high ava
 
 1. Assess whether your Kubernetes configuration must be updated to support the level of high availability that you want to achieve.  See [Configure High Availability]({{< relref "/docs/customize/ha.md" >}}).
 
-1. Upgrade Verrazzano to v1.5.0 or later.   See [Upgrade Verrazzano]({{< relref "/docs/uninstall/upgrade/_index.md" >}}).
+1. Upgrade Verrazzano to v1.5.0 or later.   See [Upgrade Verrazzano]({{< relref "/docs/upgrade/upgrade.md" >}}).
 
 1. The [examples/ha]({{< ghlink path="examples/ha/README.md" >}}) directory contains examples of highly available Verrazzano installations. The following example uses the [ha.yaml]({{< ghlink raw=true path="examples/ha/ha.yaml" >}}) file as an example of how to upgrade a default `prod` installation to a highly available Verrazzano environment.
 

--- a/content/en/docs/monitoring/_index.md
+++ b/content/en/docs/monitoring/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Logging & Monitoring"
 description: "View logging, monitoring, and diagnostic metrics"
-weight: 9
+weight: 10
 draft: false
 ---

--- a/content/en/docs/networking/_index.md
+++ b/content/en/docs/networking/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Networking"
 description: ""
-weight: 8
+weight: 9
 draft: false
 ---
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "Reference"
 description: "Verrazzano reference information"
-weight: 12
+weight: 15
 ---

--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Release Notes
 linkTitle: Release Notes
-weight: 13
+weight: 16
 draft: false
 ---
 ### v1.5.2

--- a/content/en/docs/samples/_index.md
+++ b/content/en/docs/samples/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Examples"
 description: "Example applications that demonstrate Verrazzano use case scenarios"
-weight: 12
+weight: 14
 draft: false
 ---

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Security"
 description: ""
-weight: 7
+weight: 8
 draft: false
 ---
 

--- a/content/en/docs/setup/uninstall.md
+++ b/content/en/docs/setup/uninstall.md
@@ -2,7 +2,7 @@
 title: "Uninstall"
 linkTitle: "Uninstall"
 description: "Learn how to uninstall Verrazzano"
-weight: 3
+weight: 9
 draft: false
 ---
 

--- a/content/en/docs/troubleshooting/_index.md
+++ b/content/en/docs/troubleshooting/_index.md
@@ -2,6 +2,6 @@
 title: "Troubleshooting"
 linkTitle: "Troubleshooting"
 description: "Troubleshooting Verrazzano issues"
-weight: 10
+weight: 11
 draft: false
 ---

--- a/content/en/docs/uninstall/_index.md
+++ b/content/en/docs/uninstall/_index.md
@@ -1,6 +1,0 @@
----
-title: "Upgrade, Back Up, & Uninstall"
-description: "Upgrade, back up, and uninstall Verrazzano"
-weight: 6
-draft: false
----

--- a/content/en/docs/upgrade/_index.md
+++ b/content/en/docs/upgrade/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Upgrade"
+linkTitle: "Upgrade"
+description: "Learn how to upgrade Verrazzano"
+weight: 6
+draft: false
+---

--- a/content/en/docs/upgrade/multicluster/_index.md
+++ b/content/en/docs/upgrade/multicluster/_index.md
@@ -1,11 +1,11 @@
 ---
 title: "Upgrade Multicluster Verrazzano"
 description: "Learn how to upgrade a multicluster Verrazzano environment"
-weight: 1
+weight: 2
 draft: false
 ---
 
-Each cluster of a multicluster environment is upgraded separately. Start with the admin cluster, and then for each managed cluster, follow the [Upgrade Verrazzano]({{< relref "/docs/uninstall/upgrade/_index.md" >}}) instructions.
+Each cluster of a multicluster environment is upgraded separately. Start with the admin cluster, and then for each managed cluster, follow the [Upgrade Verrazzano]({{< relref "/docs/upgrade/upgrade.md" >}}) instructions.
 
 ## Verify the upgrade of each managed cluster
 

--- a/content/en/docs/upgrade/upgrade.md
+++ b/content/en/docs/upgrade/upgrade.md
@@ -1,6 +1,6 @@
 ---
-title: "Upgrade"
-linkTitle: "Upgrade"
+title: "Upgrade Verrazzano"
+linkTitle: "Upgrade Verrazzano"
 description: "Learn how to upgrade Verrazzano"
 weight: 1
 draft: false


### PR DESCRIPTION
- Moved Backup and Upgrade documentation out of uninstall folder
- Fixes to examples used in backup and restore documentation
- Added missing details to recover the currently documented components on a different cluster