### PR TITLE
962 fixes - fix status of some targets are DOWN in prometheus at creating kind cluster step

### DIFF
--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -38,9 +38,29 @@ with one suitable for the Kind release you are using. For the supported Kubernet
 {{< clipboard >}}
 <div class="highlight">
 
-    $ kind create cluster --config - <<EOF
+    $ kind create cluster --name dev --config - <<EOF
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
+    kubeadmConfigPatches:
+    - |-
+      kind: ClusterConfiguration
+      # configure controller-manager bind address
+      controllerManager:
+        extraArgs:
+          bind-address: 0.0.0.0
+      # configure etcd metrics listen address
+      etcd:
+        local:
+          extraArgs:
+            listen-metrics-urls: http://0.0.0.0:2381
+      # configure scheduler bind address
+      scheduler:
+        extraArgs:
+          bind-address: 0.0.0.0
+    - |-
+      kind: KubeProxyConfiguration
+      # configure proxy metrics bind address
+      metricsBindAddress: 0.0.0.0
     nodes:
       - role: control-plane
         image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
@@ -92,6 +112,26 @@ because they will not need to pull the images again.
     $ kind create cluster --config - <<EOF
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
+    kubeadmConfigPatches:
+    - |-
+      kind: ClusterConfiguration
+      # configure controller-manager bind address
+      controllerManager:
+        extraArgs:
+          bind-address: 0.0.0.0
+      # configure etcd metrics listen address
+      etcd:
+        local:
+          extraArgs:
+            listen-metrics-urls: http://0.0.0.0:2381
+      # configure scheduler bind address
+      scheduler:
+        extraArgs:
+          bind-address: 0.0.0.0
+    - |-
+      kind: KubeProxyConfiguration
+      # configure proxy metrics bind address
+      metricsBindAddress: 0.0.0.0
     nodes:
       - role: control-plane
         image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -38,7 +38,7 @@ with one suitable for the Kind release you are using. For the supported Kubernet
 {{< clipboard >}}
 <div class="highlight">
 
-    $ kind create cluster --name dev --config - <<EOF
+    $ kind create cluster --config - <<EOF
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
     kubeadmConfigPatches:

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -44,22 +44,22 @@ with one suitable for the Kind release you are using. For the supported Kubernet
     kubeadmConfigPatches:
     - |-
       kind: ClusterConfiguration
-      # configure controller-manager bind address
+    # configure controller-manager bind address
       controllerManager:
         extraArgs:
           bind-address: 0.0.0.0
-      # configure etcd metrics listen address
+    # configure etcd metrics listen address
       etcd:
         local:
           extraArgs:
             listen-metrics-urls: http://0.0.0.0:2381
-      # configure scheduler bind address
+    # configure scheduler bind address
       scheduler:
         extraArgs:
           bind-address: 0.0.0.0
     - |-
       kind: KubeProxyConfiguration
-      # configure proxy metrics bind address
+    # configure proxy metrics bind address
       metricsBindAddress: 0.0.0.0
     nodes:
       - role: control-plane
@@ -115,22 +115,22 @@ because they will not need to pull the images again.
     kubeadmConfigPatches:
     - |-
       kind: ClusterConfiguration
-      # configure controller-manager bind address
+    # configure controller-manager bind address
       controllerManager:
         extraArgs:
           bind-address: 0.0.0.0
-      # configure etcd metrics listen address
+    # configure etcd metrics listen address
       etcd:
         local:
           extraArgs:
             listen-metrics-urls: http://0.0.0.0:2381
-      # configure scheduler bind address
+    # configure scheduler bind address
       scheduler:
         extraArgs:
           bind-address: 0.0.0.0
     - |-
       kind: KubeProxyConfiguration
-      # configure proxy metrics bind address
+    # configure proxy metrics bind address
       metricsBindAddress: 0.0.0.0
     nodes:
       - role: control-plane


### PR DESCRIPTION
Fix status of some targets are DOWN in prometheus at creating kind cluster step.

After investigation, the reason is that kube-controller-manager, kube-scheduler and etcd are listening on localhost.
And follow the document [troubleshooting-prometheus](https://verrazzano.io/latest/docs/troubleshooting/troubleshooting-prometheus/), we also know metricsBindAddress of kube-proxy should be binding to 0.0.0.0, it's better to do it at creating kind cluster step.

So I've modified creating kind cluster script for solve this issue.

Signed-off-by: engchina atjapan2015@yahoo.co.jp