### PR TITLE
Backport to 1.5 - Moved CLI Setup link (#967)

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -38,6 +38,8 @@ Using the Quick Start, you'll install the `dev` profile.
 
 ### Install Verrazzano using the Verrazzano CLI
 
+For information about installing the Verrazzano CLI, see [CLI Setup]({{< relref "docs/setup/cli/_index.md" >}}).
+
 1. Install Verrazzano with its `dev` profile.
 {{< clipboard >}}
 <div class="highlight">
@@ -67,8 +69,6 @@ Using the Quick Start, you'll install the `dev` profile.
 2. Wait for the installation to complete.
    Installation logs will be streamed to the command window until the installation has completed
    or until the default timeout (30m) has been reached.
-
-For information about installing the Verrazzano CLI, see [CLI Setup]({{< relref "docs/setup/cli/_index.md" >}}).
 
 **NOTE**: For some applications, the Kiali console may show warnings for objects that replicate hostname/port configurations across multiple IngressTraits. These warnings do not impact functionality and can be suppressed with the following [component override]({{< relref "docs/guides/app-deployment/application-deployment-guide.md#suppress-kiali-console-warnings" >}}).
 


### PR DESCRIPTION
Moved CLI Setup link to the top of the section.