### PR TITLE
Install Guide in 2 Pages vs. Tabs

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,3 +1,0 @@
-.td-max-width-on-larger-screens {
-    max-width: 100%;
-}

--- a/content/en/docs/access/_index.md
+++ b/content/en/docs/access/_index.md
@@ -12,7 +12,7 @@ aliases:
 Verrazzano installs several consoles. The endpoints for an installation are stored in the `Status` field of the
 installed Verrazzano Custom Resource.
 
-You can access the installation endpoints using the [Verrazzano CLI]({{< relref "/docs/setup/install/installation.md" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
+You can access the installation endpoints using the [Verrazzano CLI]({{< relref "/docs/setup/install" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
 See the following respective sections.
 
 {{< tabs tabTotal="2" >}}

--- a/content/en/docs/backup/keycloak.md
+++ b/content/en/docs/backup/keycloak.md
@@ -36,7 +36,6 @@ Before proceeding with a MySQL back up or restore operation, keep the following 
 The following example creates a secret `mysql-backup-secret` in the namespace `keycloak`.
 
 **NOTE**:  This secret must exist in the namespace `keycloak`.
-{{< clipboard >}}
 
 1. MySQL Operator requires a secret to communicate with the S3 compatible object store, so we create a `backup-secret.txt` file, which has the object store credentials.
 

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -16,7 +16,7 @@ platforms for installing Verrazzano, see [Platform Setup]({{< relref "/docs/setu
 
 **NOTE**: If you just created the cluster, then you must wait until your nodes reach `Ready` status before installing Verrazzano.
 
-For detailed Verrazzano installation instructions, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md" >}}).
+For detailed Verrazzano installation instructions, see the [Installation Guide]({{< relref "/docs/setup/install" >}}).
 
 ## Install Verrazzano
 

--- a/content/en/docs/samples/bobs-books.md
+++ b/content/en/docs/samples/bobs-books.md
@@ -6,7 +6,7 @@ description: "An example application based on WebLogic, Helidon, and Coherence"
 
 ## Before you begin
 
-* Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+* Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 * To download the example image, you must first accept the license agreement.
   * In a browser, navigate to https://container-registry.oracle.com/ and sign in.
   * Search for `example-bobbys-coherence`, `example-bobbys-front-end`, `example-bobs-books-order-manager`, `example-roberts-coherence`, and `weblogic`.

--- a/content/en/docs/samples/helidon-config/_index.md
+++ b/content/en/docs/samples/helidon-config/_index.md
@@ -5,7 +5,7 @@ This example is a Helidon-based service that returns a "HelloConfig World" respo
 
 ## Before you begin
 
-Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 
 **NOTE**: The Hello World Helidon configuration example application deployment files are contained in the Verrazzano project located at `<VERRAZZANO_HOME>/examples/helidon-config`, where `<VERRAZZANO_HOME>` is the root of the Verrazzano project.
 

--- a/content/en/docs/samples/hello-helidon/_index.md
+++ b/content/en/docs/samples/hello-helidon/_index.md
@@ -5,7 +5,7 @@ This example is a Helidon-based service that returns a “Hello World” respons
 
 ## Before you begin
 
-Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 
 **NOTE**: The Hello World Helidon example application deployment files are contained in the Verrazzano project located at `<VERRAZZANO_HOME>/examples/hello-helidon`, where `<VERRAZZANO_HOME>` is the root of the Verrazzano project.
 

--- a/content/en/docs/samples/sock-shop.md
+++ b/content/en/docs/samples/sock-shop.md
@@ -7,7 +7,7 @@ description: "Implementations of the Sock Shop Microservices Demo Application"
 
 ## Before you begin
 
-Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 
 **NOTE**: The Sock Shop example application deployment files are contained in the Verrazzano project located at
 `<VERRAZZANO_HOME>/examples/sockshop`, where `<VERRAZZANO_HOME>` is the root of the Verrazzano project.

--- a/content/en/docs/samples/spring-boot.md
+++ b/content/en/docs/samples/spring-boot.md
@@ -6,7 +6,7 @@ description: "A Spring Boot-based simple web application"
 
 ## Before you begin
 
-Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 
 **NOTE**: The Spring Boot example application deployment files are contained in the Verrazzano project located at `<VERRAZZANO_HOME>/examples/springboot-app`, where `VERRAZZANO_HOME` is the root of the Verrazzano project.
 

--- a/content/en/docs/samples/standard-kubernetes.md
+++ b/content/en/docs/samples/standard-kubernetes.md
@@ -13,7 +13,7 @@ Several standard Kubernetes resources are used in this example, both as workload
 - Ingress is used as a trait within an ApplicationConfiguration.
 
 ## Before you begin
-Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 
 ### Grant permissions
 The `oam-kubernetes-runtime` is not installed with privileges that allow it to create the Kubernetes Ingress resource used in this example.

--- a/content/en/docs/samples/todo-list.md
+++ b/content/en/docs/samples/todo-list.md
@@ -6,7 +6,7 @@ description: "An example application containing a WebLogic component"
 
 ## Before you begin
 
-* Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/installation.md" >}}) instructions.
+* Install Verrazzano by following the [installation]({{< relref "/docs/setup/install/" >}}) instructions.
 * To download the example image, you must first accept the license agreement.
   * In a browser, navigate to https://container-registry.oracle.com/ and sign in.
   * Search for `example-todo` and `weblogic`.

--- a/content/en/docs/setup/install/cli-installation.md
+++ b/content/en/docs/setup/install/cli-installation.md
@@ -1,0 +1,126 @@
+---
+title: "Install With CLI"
+description: "How to install Verrazzano with the vz CLI"
+weight: 1
+draft: false
+aliases: 
+- "/docs/setup/install/installation"
+- "/docs/setup/install/installation.md"
+---
+
+The following instructions show you how to install Verrazzano in a
+single Kubernetes cluster using the CLI.
+
+## Prerequisites
+
+- Find the Verrazzano prerequisite requirements [here]({{< relref "/docs/setup/prereqs.md" >}}).
+- Review the list of the [software versions supported]({{< relref "/docs/setup/prereqs.md#supported-software-versions" >}}) and [installed]({{< relref "/docs/setup/prereqs.md#installed-components" >}}) by Verrazzano.
+
+{{< alert title="NOTE" color="warning" >}}
+To avoid conflicts with Verrazzano system components, we recommend installing Verrazzano into an empty cluster.
+{{< /alert >}}
+
+## Prepare for the installation
+
+Before installing Verrazzano, see instructions on preparing [Kubernetes platforms]({{< relref "/docs/setup/platforms/" >}}) and installing the [Verrazzano CLI]({{< relref "docs/setup/cli/_index.md" >}}) (optional).
+Make sure that you have a valid kubeconfig file pointing to the Kubernetes cluster that you want to use for installing Verrazzano.
+
+**NOTE**: Verrazzano can create network policies that can be used to limit the ports and protocols that pods use for network communication. Network policies provide additional security but they are enforced only if you install a Kubernetes Container Network Interface (CNI) plug-in that enforces them, such as Calico. For instructions on how to install a CNI plug-in, see the documentation for your Kubernetes cluster.
+
+## Perform the installation
+
+Verrazzano provides a platform [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+to manage the life cycle of Verrazzano installations.  Using the [Verrazzano]({{< relref "/docs/reference/api/vpo-verrazzano-v1beta1" >}})
+custom resource, you can install, uninstall, and upgrade Verrazzano installations. When applying the Verrazzano custom resource, the Verrazzano CLI deploys and installs the Verrazzano platform operator; you need only to install Verrazzano as described in the following section.
+
+Verrazzano supports the following installation profiles:  development (`dev`), production (`prod`), and
+managed cluster (`managed-cluster`).  For more information, see
+[Installation Profiles]({{< relref "/docs/setup/install/profiles.md"  >}}).
+
+This document shows how to create a basic Verrazzano installation using:
+
+* The development (`dev`) installation profile
+* Wildcard-DNS, where DNS is provided by [nip.io](https://nip.io) (the default)
+
+**NOTE**: Because the `dev` profile installs self-signed certificates, when installing Verrazzano on macOS, you might see: **Your connection is not private**. For a workaround, see this [FAQ]({{< relref "/docs/faq/_index.md#enable-google-chrome-to-accept-self-signed-verrazzano-certificates" >}}).
+
+For an overview of how to configure Verrazzano, see [Modify Verrazzano Installations]({{< relref "/docs/setup/install/modify-installation.md" >}}).
+For a complete description of Verrazzano configuration options, see the
+[Verrazzano Custom Resource Definition]({{< relref "/docs/reference/api/vpo-verrazzano-v1beta1" >}}).
+
+To use other DNS options, see [Customizing DNS]({{< relref "/docs/customize/dns" >}}) for more details.
+
+#### Install Verrazzano
+
+To create a Verrazzano installation as described in the previous section, run the following commands.
+
+1. Install Verrazzano with its `dev` profile.
+{{< clipboard >}}
+```bash
+    $ vz install -f - <<EOF
+    apiVersion: install.verrazzano.io/v1beta1
+    kind: Verrazzano
+    metadata:
+      name: example-verrazzano
+    spec:
+      profile: dev
+      defaultVolumeSource:
+        persistentVolumeClaim:
+          claimName: verrazzano-storage
+      volumeClaimSpecTemplates:
+        - metadata:
+            name: verrazzano-storage
+          spec:
+            resources:
+              requests:
+                storage: 2Gi
+    EOF
+```
+{{< /clipboard >}}
+
+
+   This command installs the Verrazzano platform operator and applies the Verrazzano custom resource.
+
+2. Wait for the installation to complete.
+   Installation logs will be streamed to the command window until the installation has completed
+   or until the default timeout (30m) has been reached.
+
+To use a different profile with the previous example, set the `VZ_PROFILE` environment variable to the name of the profile you want to install.
+
+
+## Verify the installation
+
+To verify the Verrazzano installation, you can use the `vz status` command to determine the status of your installation.  After a successful installation, Verrazzano should be in the `Ready` state.
+
+{{< clipboard >}}
+```bash
+$ vz status
+
+# Sample output for a dev profile install
+Verrazzano Status
+  Name: example-verrazzano
+  Namespace: default
+  Profile: prod
+  Version: v1.5.1
+  State: Ready
+  Available Components: 23/23
+  Access Endpoints:
+    consoleUrl: https://verrazzano.default.10.0.0.1.nip.io
+    grafanaUrl: https://grafana.vmi.system.default.10.0.0.1.nip.io
+    keyCloakUrl: https://keycloak.default.10.0.0.1.nip.io
+    kialiUrl: https://kiali.vmi.system.default.10.0.0.1.nip.io
+    openSearchDashboardsUrl: https://osd.vmi.system.default.10.0.0.1.nip.io
+    openSearchUrl: https://opensearch.vmi.system.default.10.0.0.1.nip.io
+    prometheusUrl: https://prometheus.vmi.system.default.10.0.0.1.nip.io
+    rancherUrl: https://rancher.default.10.0.0.1.nip.io
+```
+{{< /clipboard >}}
+
+For installation troubleshooting help, see the [Analysis Advice]({{< relref "/docs/troubleshooting/diagnostictools/analysisadvice/" >}}).
+
+After the installation has completed, you can use the Verrazzano consoles.
+For information on how to get the consoles URLs and credentials, see [Access Verrazzano]({{< relref "/docs/access/" >}}).
+
+## Next steps
+
+(Optional) Run the example applications located [here]({{< relref "/docs/samples/_index.md" >}}).

--- a/content/en/docs/setup/install/kubectl-installation.md
+++ b/content/en/docs/setup/install/kubectl-installation.md
@@ -1,12 +1,12 @@
 ---
-title: "Install Guide"
-description: "How to install Verrazzano"
+title: "Install With Kubectl"
+description: "How to install Verrazzano with kubectl"
 weight: 1
 draft: false
 ---
 
 The following instructions show you how to install Verrazzano in a
-single Kubernetes cluster.
+single Kubernetes cluster using `kubectl`.
 
 ## Prerequisites
 
@@ -26,77 +26,6 @@ Make sure that you have a valid kubeconfig file pointing to the Kubernetes clust
 
 You can install Verrazzano using the [Verrazzano CLI]({{< relref "docs/setup/cli/_index.md" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/). See the following respective sections.
 
-{{< tabs tabTotal="2" >}}
-{{< tab tabName="vz" >}}
-<br>
-
-Verrazzano provides a platform [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
-to manage the life cycle of Verrazzano installations.  Using the [Verrazzano]({{< relref "/docs/reference/api/vpo-verrazzano-v1beta1" >}})
-custom resource, you can install, uninstall, and upgrade Verrazzano installations. When applying the Verrazzano custom resource, the Verrazzano CLI deploys and installs the Verrazzano platform operator; you need only to install Verrazzano as described in the following section.
-
-## Perform the installation
-
-Verrazzano supports the following installation profiles:  development (`dev`), production (`prod`), and
-managed cluster (`managed-cluster`).  For more information, see
-[Installation Profiles]({{< relref "/docs/setup/install/profiles.md"  >}}).
-
-This document shows how to create a basic Verrazzano installation using:
-
-* The development (`dev`) installation profile
-* Wildcard-DNS, where DNS is provided by [nip.io](https://nip.io) (the default)
-
-**NOTE**: Because the `dev` profile installs self-signed certificates, when installing Verrazzano on macOS, you might see: **Your connection is not private**. For a workaround, see this [FAQ]({{< relref "/docs/faq/_index.md#enable-google-chrome-to-accept-self-signed-verrazzano-certificates" >}}).
-
-For an overview of how to configure Verrazzano, see [Modify Verrazzano Installations]({{< relref "/docs/setup/install/modify-installation.md" >}}).
-For a complete description of Verrazzano configuration options, see the
-[Verrazzano Custom Resource Definition]({{< relref "/docs/reference/api/vpo-verrazzano-v1beta1" >}}).
-
-To use other DNS options, see [Customizing DNS]({{< relref "/docs/customize/dns" >}}) for more details.
-
-#### Install Verrazzano
-
-To create a Verrazzano installation as described in the previous section, run the following commands.
-
-1. Install Verrazzano with its `dev` profile.
-{{< clipboard >}}
-<div class="highlight">
-
-
-    $ vz install -f - <<EOF
-    apiVersion: install.verrazzano.io/v1beta1
-    kind: Verrazzano
-    metadata:
-      name: example-verrazzano
-    spec:
-      profile: dev
-      defaultVolumeSource:
-        persistentVolumeClaim:
-          claimName: verrazzano-storage
-      volumeClaimSpecTemplates:
-        - metadata:
-            name: verrazzano-storage
-          spec:
-            resources:
-              requests:
-                storage: 2Gi
-    EOF
-
-</div>
-{{< /clipboard >}}
-
-
-   This command installs the Verrazzano platform operator and applies the Verrazzano custom resource.
-
-2. Wait for the installation to complete.
-   Installation logs will be streamed to the command window until the installation has completed
-   or until the default timeout (30m) has been reached.
-
-To use a different profile with the previous example, set the `VZ_PROFILE` environment variable to the name of the profile you want to install.
-
-{{< /tab >}}
-{{< tab tabName="kubectl" >}}
-<br>
-
 ## Install the Verrazzano platform operator
 
 Verrazzano provides a platform [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
@@ -107,34 +36,25 @@ To install the Verrazzano platform operator:
 
 1. Deploy the Verrazzano platform operator.
 {{< clipboard >}}
-<div class="highlight">
-
-   ```
+   ```bash
    $ kubectl apply -f {{<release_asset_operator_url verrazzano-platform-operator.yaml>}}
    ```
-</div>
 {{< /clipboard >}}
 
 2. Wait for the deployment to complete.
-
 {{< clipboard >}}
-<div class="highlight">
-
-   ```
+   ```bash
    $ kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
    ```
    ```
    # Expected response
    deployment "verrazzano-platform-operator" successfully rolled out
    ```
-</div>
 {{< /clipboard >}}
 
 3. Confirm that the operator pod is correctly defined and running.
 {{< clipboard >}}
-<div class="highlight">
-
-  ```
+  ```bash
    $ kubectl -n verrazzano-install get pods
    ```
    ```
@@ -142,7 +62,6 @@ To install the Verrazzano platform operator:
     NAME                                            READY   STATUS    RESTARTS   AGE
     verrazzano-platform-operator-59d5c585fd-lwhsx   1/1     Running   0          114s
    ```
-</div>
 {{< /clipboard >}}
 
 ## Perform the installation
@@ -168,9 +87,7 @@ To use other DNS options, see [Customzing DNS]({{< relref "/docs/customize/dns" 
 To create a Verrazzano installation as described in the previous section, run the following commands.
 
 {{< clipboard >}}
-<div class="highlight">
-
-```
+```bash
 $ kubectl apply -f - <<EOF
 apiVersion: install.verrazzano.io/v1beta1
 kind: Verrazzano
@@ -180,19 +97,13 @@ spec:
   profile: ${VZ_PROFILE:-dev}
 EOF
 ```
-
-</div>
 {{< /clipboard >}}
 
 {{< clipboard >}}
-<div class="highlight">
-
-```
+```bash
 $ kubectl wait \
     --timeout=20m \
     --for=condition=InstallComplete verrazzano/example-verrazzano
-```
-</div>
 {{< /clipboard >}}
 
 To use a different profile with the previous example, set the `VZ_PROFILE` environment variable to the name of the profile
@@ -201,9 +112,7 @@ you want to install.
 If an error occurs, check the log output of the installation. You can view the logs with the following command.
 
 {{< clipboard >}}
-<div class="highlight">
-
-```
+```bash
 $ kubectl logs -n verrazzano-install \
     -f $(kubectl get pod \
     -n verrazzano-install \
@@ -211,42 +120,35 @@ $ kubectl logs -n verrazzano-install \
     -o jsonpath="{.items[0].metadata.name}") | grep '^{.*}$' \
     | jq -r '."@timestamp" as $timestamp | "\($timestamp) \(.level) \(.message)"'
 ```
-</div>
 {{< /clipboard >}}
-
-{{< /tab >}}
-{{< /tabs >}}
-
 
 ## Verify the installation
 
 Verrazzano installs multiple objects in multiple namespaces. In the `verrazzano-system` namespaces, all the pods in the `Running` state, does not guarantee, but likely indicates that Verrazzano is up and running.
 {{< clipboard >}}
-<div class="highlight">
+To verify the Verrazzano installation, you can use the `vz status` command to determine the status of your installation.  After a successful installation, Verrazzano should be in the `Ready` state.
 
-```
-$ kubectl get pods -n verrazzano-system
+```bash
+$ vz status
 
 # Sample output for a dev profile install
-NAME                                                       READY   STATUS    RESTARTS   AGE
-coherence-operator-d5565cd5d-dkm95                         1/1     Running   0          9m49s
-fluentd-sgtcg                                              2/2     Running   0          2m46s
-oam-kubernetes-runtime-665ff44c8-ldbqv                     1/1     Running   0          11m
-verrazzano-application-operator-9f87f7897-25crr            1/1     Running   0          9m37s
-verrazzano-application-operator-webhook-5bd7ccbb45-wp874   1/1     Running   0          9m37s
-verrazzano-authproxy-66767cdfc5-lsc22                      3/3     Running   0          8m31s
-verrazzano-cluster-operator-994fb6c7d-29pd7                1/1     Running   0          9m41s
-verrazzano-cluster-operator-webhook-85b85f89f4-25jgj       1/1     Running   0          9m41s
-verrazzano-console-7d999bf7-6nncm                          2/2     Running   0          8m9s
-verrazzano-monitoring-operator-754c897d65-jfmb9            2/2     Running   0          8m35s
-vmi-system-es-master-0                                     2/2     Running   0          7m59s
-vmi-system-grafana-6966f9965d-cm5pz                        3/3     Running   0          7m58s
-vmi-system-kiali-5bcfb7f775-9cc5h                          2/2     Running   0          8m28s
-vmi-system-osd-6c974854df-klgpv                            2/2     Running   0          6m2s
-weblogic-operator-c4f766c7c-knmpx                          2/2     Running   0          9m33s
-weblogic-operator-webhook-547b9756f4-454rq                 1/1     Running   0          9m33s
+Verrazzano Status
+  Name: example-verrazzano
+  Namespace: default
+  Profile: prod
+  Version: v1.5.1
+  State: Ready
+  Available Components: 23/23
+  Access Endpoints:
+    consoleUrl: https://verrazzano.default.10.0.0.1.nip.io
+    grafanaUrl: https://grafana.vmi.system.default.10.0.0.1.nip.io
+    keyCloakUrl: https://keycloak.default.10.0.0.1.nip.io
+    kialiUrl: https://kiali.vmi.system.default.10.0.0.1.nip.io
+    openSearchDashboardsUrl: https://osd.vmi.system.default.10.0.0.1.nip.io
+    openSearchUrl: https://opensearch.vmi.system.default.10.0.0.1.nip.io
+    prometheusUrl: https://prometheus.vmi.system.default.10.0.0.1.nip.io
+    rancherUrl: https://rancher.default.10.0.0.1.nip.io
 ```
-</div>
 {{< /clipboard >}}
 
 For installation troubleshooting help, see [Analysis Advice]({{< relref "/docs/troubleshooting/diagnostictools/analysisadvice/" >}}).

--- a/content/en/docs/setup/install/mc-install/multicluster.md
+++ b/content/en/docs/setup/install/mc-install/multicluster.md
@@ -28,7 +28,7 @@ To install Verrazzano on each Kubernetes cluster, complete the following steps:
 <br>**NOTE**: You also can use the `dev` or `prod` profile.
 
 For detailed instructions on how to install and customize Verrazzano on a Kubernetes cluster using a specific profile,
-see the [Installation Guide]({{< relref "/docs/setup/install/installation.md" >}}) and [Installation Profiles]({{< relref "/docs/setup/install/profiles.md" >}}).
+see the [Installation Guide]({{< relref "/docs/setup/install/" >}}) and [Installation Profiles]({{< relref "/docs/setup/install/profiles.md" >}}).
 
 ## Register the managed cluster
 

--- a/content/en/docs/setup/install/modify-installation.md
+++ b/content/en/docs/setup/install/modify-installation.md
@@ -70,7 +70,7 @@ $ vz install -f verrazzano.yaml
 </div>
 {{< /clipboard >}}
 
-For detailed installation instructions, see the [Install Guide]({{< relref "/docs/setup/install/installation.md" >}}).
+For detailed installation instructions, see the [Install Guide]({{< relref "/docs/setup/install/" >}}).
 
 ### Post-Installation
 

--- a/content/en/docs/setup/platforms/Generic/generic.md
+++ b/content/en/docs/setup/platforms/Generic/generic.md
@@ -9,7 +9,7 @@ draft: false
 ## Prepare for the generic install
 
 Verrazzano requires that your Kubernetes cluster provides an implementation of network load balancers ([Services of type LoadBalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)) for a production environment. If your generic Kubernetes implementation provides this feature, then you can use a default configuration
-of the Verrazzano custom resource with no customizations and follow the [Installation Guide]({{< relref "/docs/setup/install/installation.md" >}}).
+of the Verrazzano custom resource with no customizations and follow the [Installation Guide]({{< relref "/docs/setup/install/" >}}).
 
 
 {{% alert title="NOTE" color="warning" %}}
@@ -29,4 +29,4 @@ Verrazzano is highly customizable.  If your Kubernetes implementation requires a
 
 ## Next steps
 
-To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
+To continue, see the [Installation Guide]({{< relref "/docs/setup/install" >}}).

--- a/content/en/docs/setup/platforms/OCI/OCI.md
+++ b/content/en/docs/setup/platforms/OCI/OCI.md
@@ -30,4 +30,4 @@ draft: false
 
 ## Next steps
 
-To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
+To continue, see the [Installation Guide]({{< relref "/docs/setup/install/" >}}).

--- a/content/en/docs/setup/platforms/OLCNE/OLCNE.md
+++ b/content/en/docs/setup/platforms/OLCNE/OLCNE.md
@@ -141,4 +141,4 @@ Other values can be used if required.
 
 ## Next steps
 
-To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
+To continue, see the [Installation Guide]({{< relref "/docs/setup/install/" >}}).

--- a/content/en/docs/setup/platforms/kind/kind.md
+++ b/content/en/docs/setup/platforms/kind/kind.md
@@ -197,4 +197,4 @@ For use by MetalLB, assign a range of IP addresses at the end of the `kind` netw
 
 ## Next steps
 
-To continue, see the [Installation Guide]({{< relref "/docs/setup/install/installation.md#install-the-verrazzano-platform-operator" >}}).
+To continue, see the [Installation Guide]({{< relref "/docs/setup/install" >}}).

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/IngressInstallFailure.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/IngressInstallFailure.md
@@ -14,6 +14,6 @@ Analysis detected that the Verrazzano installation has failed related to the NGI
 Review the analysis data, which might help identify the issue.
 
 ### Related information
-* [Installation Guide]({{< relref "/docs/setup/install/installation.md" >}})
+* [Installation Guide]({{< relref "/docs/setup/install/" >}})
 * [Platform Setup]({{< relref "/docs/setup/platforms/_index.md" >}})
 * [Kubernetes Troubleshooting](https://kubernetes.io/docs/tasks/debug/)

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/InstallFailure.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/InstallFailure.md
@@ -13,5 +13,5 @@ Analysis detected a failure while installing, upgrading, or uninstalling Verrazz
 Review the analysis data, which can help identify the issue. Upon failure, a bug-report archive file will be generated automatically and the filepath will be printed to the console. 
 
 ### Related information
-* [Installation Guide]({{< relref "/docs/setup/install/installation.md" >}})
+* [Installation Guide]({{< relref "/docs/setup/install/" >}})
 * [Kubernetes Troubleshooting](https://kubernetes.io/docs/tasks/debug/)

--- a/content/en/docs/uninstall/uninstall.md
+++ b/content/en/docs/uninstall/uninstall.md
@@ -6,7 +6,7 @@ weight: 2
 draft: false
 ---
 
-You can uninstall Verrazzano using the [Verrazzano CLI]({{< relref "/docs/setup/install/installation.md" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
+You can uninstall Verrazzano using the [Verrazzano CLI]({{< relref "/docs/setup/install/" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
 
 See the following respective sections:
 - [Uninstall using the Verrazzano CLI]({{< relref "#uninstall-using-the-verrazzano-cli" >}})

--- a/content/en/docs/upgrade/upgrade.md
+++ b/content/en/docs/upgrade/upgrade.md
@@ -29,7 +29,7 @@ The platform operator contains the newer component charts and image versions, so
 Updating the platform operator has no effect on an existing installation until you initiate the Verrazzano installation upgrade.
 Currently, there is no way to roll back either the platform operator update or the Verrazzano installation upgrade.  
 
-You can upgrade Verrazzano using the  [Verrazzano CLI]({{< relref "/docs/setup/install/installation.md" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
+You can upgrade Verrazzano using the  [Verrazzano CLI]({{< relref "/docs/setup/install" >}}) or with [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/).
 See the following respective sections.
 
 {{< alert title="NOTE" color="warning" >}}For optimal functionality, be sure to install or upgrade the CLI version to match the Verrazzano version to which you are upgrading.   


### PR DESCRIPTION
Split installation guide into 2 documents, one using CLI other using kubectl.  There was a formatting problem due to the usage of tabs that really could only be resolved properly by discontinuing use of tabs. Docsy tab formatting interferes with hugo-dynamic-tabs as they both use underlying bootstrap tab panes but style them differently.

See before (right) / after (left):

![Screenshot 2023-03-30 at 4 54 36 PM](https://user-images.githubusercontent.com/2422580/228964070-2ef2fd69-f10b-40d1-bf40-892b0b32104e.png)
![Screenshot 2023-03-30 at 5 08 41 PM](https://user-images.githubusercontent.com/2422580/228965075-ac73e50a-981b-4d56-95e6-0229f238b54b.png)
