### PR TITLE
Update WebLogic Kubernetes Operator and WebLogic Monitoring Exporter versions

### DIFF
--- a/content/en/docs/releasenotes/_index.md
+++ b/content/en/docs/releasenotes/_index.md
@@ -7,6 +7,8 @@ draft: false
 ### v1.6.0
 Component version updates:
 - Jaeger v1.42.0
+- WebLogic Kubernetes Operator v4.0.6
+- WebLogic Monitoring Exporter v2.1.3
 
 ### v1.5.2
 Component version updates:

--- a/content/en/docs/setup/prereqs.md
+++ b/content/en/docs/setup/prereqs.md
@@ -89,5 +89,5 @@ component, its version, and a brief description.
 | Rancher                      | 2.7.1       | Manages multiple Kubernetes clusters.                                                    |
 | Rancher Backup Operator      | 2.1.3       | Manages backup and restore of Rancher configurations and data.                           |
 | Velero                       | 1.9.1       | Manages backup and restore of Kubernetes configurations and data.                        |
-| WebLogic Kubernetes Operator | 4.0.5       | Assists with deploying and managing WebLogic domains.                                    |
-| WebLogic Monitoring Exporter | 2.1.2       | Exports Prometheus-compatible metrics from WebLogic instances.                           |
+| WebLogic Kubernetes Operator | 4.0.6       | Assists with deploying and managing WebLogic domains.                                    |
+| WebLogic Monitoring Exporter | 2.1.3       | Exports Prometheus-compatible metrics from WebLogic instances.                           |


### PR DESCRIPTION
This PR updates the document to set the correct versions of WebLogic Kubernetes Operator and WebLogic Monitoring Exporter.