### PR TITLE
add note for mandatory external IPs

### DIFF
--- a/content/en/docs/customize/externalLBs.md
+++ b/content/en/docs/customize/externalLBs.md
@@ -33,6 +33,9 @@ The following is an example of using external load balancers for both management
 
   - Set `NodePort` as the ingress type in the [Ingress Component]({{< relref "/docs/reference/API/vpo-verrazzano-v1beta1.md#install.verrazzano.io/v1beta1.IngressNginxComponent" >}}).
   - Set `controller.service.externalIPs` with the IP address for the external management load balancer in the [Ingress NGINX Overrides]({{< relref "/docs/reference/API/vpo-verrazzano-v1beta1#install.verrazzano.io/v1beta1.IngressNginxComponent" >}}).
+
+    **NOTE**: If the ingress type is `NodePort`, then a valid and accessible IP address **must** be specified using the `controller.service.externalIPs` key in NGINXInstallArgs.
+
   - Set `ports` in the [Ingress Component]({{< relref "/docs/reference/API/vpo-verrazzano-v1beta1#install.verrazzano.io/v1beta1.IngressNginxComponent" >}}) with a [PortConfig](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#serviceport-v1-core) that has `443` as `port`, `31443` as `nodePort`, `https` as `targetPort`, and `TCP` as `protocol`.
 
 * External load balancer for application ingress using the Istio ingress gateway overrides:


### PR DESCRIPTION
Added mandatory statement to doc, as per [VZ-9325](https://jira.oraclecorp.com/jira/browse/VZ-9325) External IPs must be mandatory when using NodePort