### PR TITLE
VZ-9545: Updates to the private registry installation instructions

### DIFF
--- a/content/en/docs/setup/private-registry/private-registry.md
+++ b/content/en/docs/setup/private-registry/private-registry.md
@@ -113,6 +113,16 @@ You must have the following software installed:
 
      d. Although most images can be protected using credentials stored in an image pull secret, some images _must_ be public. Use the following commands to get the list of public images:
 
+      * The Rancher Agent image.
+{{< clipboard >}}
+<div class="highlight">
+
+   ```
+   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+   ```
+</div>
+{{< /clipboard >}}
+
       * All the Rancher images in the `rancher/additional-rancher` subcomponent.
 {{< clipboard >}}
 <div class="highlight">
@@ -123,43 +133,15 @@ You must have the following software installed:
 </div>
 {{< /clipboard >}}
 
-      * The Fluentd Kubernetes daemonset image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "fluentd-kubernetes-daemonset") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-      * The Istio proxy image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] |  select(.name == "istiod") | .images[] | select(.image == "proxyv2") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-      * The WebLogic Monitoring Exporter image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "weblogic-monitoring-exporter") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-
-      * The Verrazzano platform operator image identified by `$VPO_IMAGE`, as defined previously in Step 3.b.
-      * For all the Verrazzano Docker images in the private registry that are not explicitly marked public, you will need to create the secret `verrazzano-container-registry` in the `default` namespace, with the appropriate credentials for the registry, identified by `$MYREG`.    
+      * For all the Verrazzano Docker images in the private registry that are not explicitly marked public, you will need to create the secret `verrazzano-container-registry` in the `verrazzano-install` namespace, with the appropriate credentials for the registry, identified by `$MYREG`.
        For example:
 {{< clipboard >}}
 <div class="highlight">
 
    ```
-   $ kubectl create secret docker-registry verrazzano-container-registry \  
-  	 --docker-server=$MYREG --docker-username=myreguser \  
+   $ kubectl create namespace verrazzano-install
+   $ kubectl create secret docker-registry verrazzano-container-registry -n verrazzano-install \
+  	 --docker-server=$MYREG --docker-username=myreguser \
   	 --docker-password=xxxxxxxx --docker-email=me@example.com
    ```     
 </div>
@@ -174,7 +156,7 @@ You must have the following software installed:
    ```
    $ helm template --include-crds ${DISTRIBUTION_DIR}/manifests/charts/verrazzano-platform-operator \
      --set image=${MYREG}/${MYREPO}/${VPO_IMAGE} --set global.registry=${MYREG} \
-     --set global.repository=${MYREPO} --set global.imagePullSecrets={verrazzano-container-registry} | kubectl apply -f -
+     --set global.repository=${MYREPO} | kubectl apply -f -
    ```
 </div>
 {{< /clipboard >}}
@@ -235,3 +217,10 @@ For example, for the [Oracle Cloud Native Environment platform]({{< relref "/doc
  ```
 </div>
 {{< /clipboard >}}
+
+## WebLogic applications
+
+WebLogic applications require that the container registry secret be specified in the `Domain` resource. Create a registry secret in the application namespace and specify the secret in
+the `imagePullSecrets` field of the WebLogic `Domain` spec for the application.
+
+For an example, see the [ToDo List]( {{< release_source_url path=examples/todo-list/todo-list-components.yaml >}} ) example application component YAML file.


### PR DESCRIPTION
This PR simplifies and adds missing information to the private registry installation instructions, and includes the following:
- Removes instructions for identifying images that need to be public in the private registry that are not needed
- Updates the instructions for creating the registry secret to create the secret in the `verrazzano-install` namespace instead of the default namespace
- Removes a CLI switch on the `helm template` command that is no longer needed
- Adds a section for WebLogic applications in a private registry environment

I have updated both versions (lite and full) of the private registry instructions.