### PR TITLE
VZ-9545: Updates to private registry pages

### DIFF
--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -179,12 +179,21 @@ Load the product images into your private registry.
 {{< /clipboard >}}
 4. Although most images can be protected using credentials stored in an image pull secret, some images _must_ be public. Use the following commands to get the list of public images:
 
-   * The Rancher Agent image and all the Rancher images in the `rancher/additional-rancher` subcomponent.
+   * The Rancher Agent image.
 {{< clipboard >}}
 <div class="highlight">
 
    ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+   ```
+</div>
+{{< /clipboard >}}
+
+   * All the Rancher images in the `rancher/additional-rancher` subcomponent.
+{{< clipboard >}}
+<div class="highlight">
+
+   ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
    ```
 </div>

--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -179,42 +179,13 @@ Load the product images into your private registry.
 {{< /clipboard >}}
 4. Although most images can be protected using credentials stored in an image pull secret, some images _must_ be public. Use the following commands to get the list of public images:
 
-   * All the Rancher images in the `rancher/additional-rancher` subcomponent.
+   * The Rancher Agent image and all the Rancher images in the `rancher/additional-rancher` subcomponent.
 {{< clipboard >}}
 <div class="highlight">
 
    ```
+   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-
-   * The Fluentd Kubernetes daemonset image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "fluentd-kubernetes-daemonset") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-
-   * The Istio proxy image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] |  select(.name == "istiod") | .images[] | select(.image == "proxyv2") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-
-   * The WebLogic Monitoring Exporter image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "weblogic-monitoring-exporter") | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}
@@ -304,3 +275,10 @@ For example, for the [Oracle Cloud Native Environment platform]({{< relref "/doc
  ```
 </div>
 {{< /clipboard >}}
+
+## WebLogic applications
+
+WebLogic applications require that the container registry secret be specified in the `Domain` resource. Create a registry secret in the application namespace and specify the secret in
+the `imagePullSecrets` field of the WebLogic [Domain](https://github.com/oracle/weblogic-kubernetes-operator/blob/main/documentation/domains/Domain.md#domain-spec) spec for the application.
+
+For an example, see the [ToDo List]( {{< release_source_url path=examples/todo-list/todo-list-components.yaml >}} ) example application component YAML file.

--- a/content/en/docs/setup/private-registry/private-registry.md
+++ b/content/en/docs/setup/private-registry/private-registry.md
@@ -113,20 +113,30 @@ You must have the following software installed:
 
      d. Although most images can be protected using credentials stored in an image pull secret, some images _must_ be public. Use the following commands to get the list of public images:
 
-   * The Rancher Agent image and all the Rancher images in the `rancher/additional-rancher` subcomponent.
+   * The Rancher Agent image.
 {{< clipboard >}}
 <div class="highlight">
 
    ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+   ```
+</div>
+{{< /clipboard >}}
+
+   * All the Rancher images in the `rancher/additional-rancher` subcomponent.
+{{< clipboard >}}
+<div class="highlight">
+
+   ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}
 
-      * The Verrazzano platform operator image identified by `$VPO_IMAGE`, as defined previously in Step 3.b.
-      * For all the Verrazzano Docker images in the private registry that are not explicitly marked public, you will need to create the secret `verrazzano-container-registry` in the `default` namespace, with the appropriate credentials for the registry, identified by `$MYREG`.    
-       For example:
+   * The Verrazzano platform operator image identified by `$VPO_IMAGE`, as defined previously in Step 3.b.
+
+   * For all the Verrazzano Docker images in the private registry that are not explicitly marked public, you will need to create the secret `verrazzano-container-registry` in the `default` namespace, with the appropriate credentials for the registry, identified by `$MYREG`.
+   For example:
 {{< clipboard >}}
 <div class="highlight">
 

--- a/content/en/docs/setup/private-registry/private-registry.md
+++ b/content/en/docs/setup/private-registry/private-registry.md
@@ -113,40 +113,13 @@ You must have the following software installed:
 
      d. Although most images can be protected using credentials stored in an image pull secret, some images _must_ be public. Use the following commands to get the list of public images:
 
-      * All the Rancher images in the `rancher/additional-rancher` subcomponent.
+   * The Rancher Agent image and all the Rancher images in the `rancher/additional-rancher` subcomponent.
 {{< clipboard >}}
 <div class="highlight">
 
    ```
+   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-
-      * The Fluentd Kubernetes daemonset image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "fluentd-kubernetes-daemonset") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-      * The Istio proxy image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] |  select(.name == "istiod") | .images[] | select(.image == "proxyv2") | "\(.image):\(.tag)"'
-   ```
-</div>
-{{< /clipboard >}}
-      * The WebLogic Monitoring Exporter image.
-{{< clipboard >}}
-<div class="highlight">
-
-   ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[].images[] | select(.image == "weblogic-monitoring-exporter") | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}
@@ -235,3 +208,10 @@ For example, for the [Oracle Cloud Native Environment platform]({{< relref "/doc
  ```
 </div>
 {{< /clipboard >}}
+
+## WebLogic applications
+
+WebLogic applications require that the container registry secret be specified in the `Domain` resource. Create a registry secret in the application namespace and specify the secret in
+the `imagePullSecrets` field of the WebLogic [Domain](https://github.com/oracle/weblogic-kubernetes-operator/blob/main/documentation/domains/Domain.md#domain-spec) spec for the application.
+
+For an example, see the [ToDo List]( {{< release_source_url path=examples/todo-list/todo-list-components.yaml >}} ) example application component YAML file.


### PR DESCRIPTION
This PR includes:
- Simplified instructions in the "loading images" section (several bullet items removed)
- Added Rancher Agent to the list of images that needs to be public
- Added a section for WebLogic applications