### PR TITLE
Fix bad Rancher jq command

### DIFF
--- a/content/en/docs/setup/private-registry/private-registry-full-distribution.md
+++ b/content/en/docs/setup/private-registry/private-registry-full-distribution.md
@@ -182,7 +182,7 @@ Load the product images into your private registry.
 <div class="highlight">
 
    ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}

--- a/content/en/docs/setup/private-registry/private-registry.md
+++ b/content/en/docs/setup/private-registry/private-registry.md
@@ -116,7 +116,7 @@ You must have the following software installed:
 <div class="highlight">
 
    ```
-   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+   $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}


### PR DESCRIPTION
The `jq` command to get the Rancher Agent image was wrong, it returned no images. This PR fixes the command.