### PR TITLE
update TOC levels

### DIFF
--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -25,5 +25,5 @@ defaultMarkdownHandler = "goldmark"
 
 # Specify which level of headings to show in the right-side TOC
 [tableOfContents]
-  endLevel = 2
+  endLevel = 3
   startLevel = 1


### PR DESCRIPTION
As was done for the master branch docs, update the 1.5 docs, right-side TOC levels to include heading level 3.