### PR TITLE
VZ-10008: Fix OS and OSD references

### DIFF
--- a/content/en/docs/applications/oam/deploy-app.md
+++ b/content/en/docs/applications/oam/deploy-app.md
@@ -341,10 +341,10 @@ and enabled for Istio.
 
    # Sample output
    NAME                                               READY   STATUS    RESTARTS   AGE
-   vmi-system-os-master-0                             2/2     Running   0          47m
+   vmi-system-es-master-0                             2/2     Running   0          47m
    vmi-system-grafana-799d79648d-wsdp4                2/2     Running   0          47m
    vmi-system-kiali-574c6dd94d-f49jv                  2/2     Running   0          51m
-   vmi-system-opensearchDashboards-77f8d998f4-zzvqr   2/2     Running   0          47m
+   vmi-system-osd-77f8d998f4-zzvqr   2/2     Running   0          47m
    ```
 
 </div>
@@ -369,10 +369,10 @@ and enabled for Istio.
    monitoring stack created by Verrazzano for the deployed applications.
 
    The monitoring infrastructure comprises several components:
-   * `vmi-system-os` - OpenSearch for log collection
+   * `vmi-system-es` - OpenSearch for log collection
    * `vmi-system-grafana` - Grafana for metric visualization
    * `vms-system-kiali` - Kiali for management console of `istio` service mesh
-   * `vmi-system-opensearchDashboards` - OpenSearch Dashboards for log visualization
+   * `vmi-system-osd` - OpenSearch Dashboards for log visualization
    * `prometheus-prometheus-operator-kube-p-prometheus` - Prometheus for metric collection
    <p/>
 
@@ -549,7 +549,7 @@ Determine the URL to access OpenSearch Dashboards:
 
  ```
 $ OSD_HOST=$(kubectl get ingress \
-      -n verrazzano-system vmi-system-opensearchDashboards \
+      -n verrazzano-system vmi-system-osd \
       -o jsonpath='{.spec.rules[0].host}')
 $ OSD_URL="https://${OSD_HOST}"
 $ echo "${OSD_URL}"

--- a/content/en/docs/guides/ha/prod-upgrade.md
+++ b/content/en/docs/guides/ha/prod-upgrade.md
@@ -118,7 +118,7 @@ The exact steps required to upgrade a Verrazzano environment to achieve high ava
                  replicas: 2
        opensearch:
          nodes:
-         - name: os-ingest
+         - name: es-ingest
            replicas: 2
    EOF
    ```

--- a/content/en/docs/observability/logging/configure-opensearch/opensearch.md
+++ b/content/en/docs/observability/logging/configure-opensearch/opensearch.md
@@ -182,11 +182,11 @@ spec:
             requests:
               memory: 1Gi
         # Override the default node groups because we are providing our own topology.
-        - name: os-master
+        - name: es-master
           replicas: 0
-        - name: os-data
+        - name: es-data
           replicas: 0
-        - name: os-ingest
+        - name: es-ingest
           replicas: 0
 ```
 {{< /clipboard >}}
@@ -221,7 +221,7 @@ pod/vmi-system-data-ingest-1-8d7db6489-kdhbv           2/2     Running    1     
 pod/vmi-system-data-ingest-2-699d6bdd9c-z7nzx          2/2     Running    0          5m21s
 pod/vmi-system-grafana-7947cdd84b-b7mks                2/2     Running    0          5m21s
 pod/vmi-system-kiali-6c7bd6658b-d2zq9                  2/2     Running    0          5m37s
-pod/vmi-system-opensearchDashboards-7d47f65dfc-zhjxp   2/2     Running    0          5m21s
+pod/vmi-system-osd-7d47f65dfc-zhjxp   2/2     Running    0          5m21s
 pod/vmi-system-master-0                                2/2     Running    0          5m21s
 pod/vmi-system-master-1                                2/2     Running    0          5m21s
 pod/vmi-system-master-2                                2/2     Running    0          5m21s
@@ -238,7 +238,7 @@ requested amount of memory.
 
 ```
 Containers:
-  os-data:
+  es-data:
     ...
     Requests:
       memory:   1Gi

--- a/content/en/docs/observability/logging/configure-opensearch/opensearch.md
+++ b/content/en/docs/observability/logging/configure-opensearch/opensearch.md
@@ -201,9 +201,9 @@ $ kubectl get pvc,pod -l verrazzano-component=opensearch -n verrazzano-system
 
 # Sample output
 NAME                                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-persistentvolumeclaim/opensearch-master-vmi-system-master-0      Bound    pvc-9ace042a-dd68-4975-816d-f2ca0dc4d9d8   50Gi       RWO            standard       5m22s
-persistentvolumeclaim/opensearch-master-vmi-system-master-1      Bound    pvc-8bf68c2c-235e-4bd5-8741-5a5cd3453934   50Gi       RWO            standard       5m21s
-persistentvolumeclaim/opensearch-master-vmi-system-master-2      Bound    pvc-da8a48b1-5762-4669-98f0-8479f30043fc   50Gi       RWO            standard       5m21s
+persistentvolumeclaim/elasticsearch-master-vmi-system-master-0      Bound    pvc-9ace042a-dd68-4975-816d-f2ca0dc4d9d8   50Gi       RWO            standard       5m22s
+persistentvolumeclaim/elasticsearch-master-vmi-system-master-1      Bound    pvc-8bf68c2c-235e-4bd5-8741-5a5cd3453934   50Gi       RWO            standard       5m21s
+persistentvolumeclaim/elasticsearch-master-vmi-system-master-2      Bound    pvc-da8a48b1-5762-4669-98f0-8479f30043fc   50Gi       RWO            standard       5m21s
 persistentvolumeclaim/vmi-system-data-ingest                     Bound    pvc-7ad9f275-632b-4aac-b7bf-c5115215937c   100Gi      RWO            standard       5m23s
 persistentvolumeclaim/vmi-system-data-ingest-1                   Bound    pvc-8a293e51-2c20-4cae-916b-1ce46a780403   100Gi      RWO            standard       5m23s
 persistentvolumeclaim/vmi-system-data-ingest-2                   Bound    pvc-0025fcef-1d8c-4307-977c-3921545c6730   100Gi      RWO            standard       5m22s

--- a/content/en/docs/observability/logging/fluentd/_index.md
+++ b/content/en/docs/observability/logging/fluentd/_index.md
@@ -84,6 +84,6 @@ Each instance pulls logs from the node's `/var/log/containers` directory and wri
 Verrazzano system applications receive special handling, and write their logs to the `verrazzano-system` data stream.
 Verrazzano application logs are exported to a data stream based on the application's namespace, following this format: `verrazzano-application-<application namespace>`.
 
-For example, `vmi-system-opensearchDashboards` logs written to `/var/log/containers` will be pulled by Fluentd and written to OpenSearch.  The logs are exported
-to the `verrazzano-system` data stream, because `vmi-system-opensearchDashboards` is a Verrazzano system application. For a non-system application, if it is in the `myapp` namespace,
+For example, `vmi-system-osd` logs written to `/var/log/containers` will be pulled by Fluentd and written to OpenSearch.  The logs are exported
+to the `verrazzano-system` data stream, because `vmi-system-osd` is a Verrazzano system application. For a non-system application, if it is in the `myapp` namespace,
 then its logs will be exported to the `verrazzano-application-myapp` data stream.

--- a/content/en/docs/observability/tracing/configure-tracing.md
+++ b/content/en/docs/observability/tracing/configure-tracing.md
@@ -116,8 +116,8 @@ with a TLS CA certificate mounted from a volume and the user/password stored in 
 
    ```
    $ kubectl create secret generic jaeger-secret \
-    --from-literal=OS_PASSWORD=<OPENSEARCH PASSWORD> \
-    --from-literal=OS_USERNAME=<OPENSEARCH USERNAME> \
+    --from-literal=ES_PASSWORD=<OPENSEARCH PASSWORD> \
+    --from-literal=ES_USERNAME=<OPENSEARCH USERNAME> \
     --from-file=ca-bundle=<path to the file containing CA certs> \
     -n verrazzano-install
    ```

--- a/content/en/docs/setup/access/console-urls.md
+++ b/content/en/docs/setup/access/console-urls.md
@@ -79,7 +79,7 @@ The resulting output is similar to the following (abbreviated to show only the r
       grafanaUrl: https://grafana.vmi.system.default.11.22.33.44.nip.io
       keyCloakUrl: https://keycloak.default.11.22.33.44.nip.io
       kialiUrl: https://kiali.vmi.system.default.11.22.33.44.nip.io
-      opensearchDashboardsUrl: https://opensearchDashboards.vmi.system.default.11.22.33.44.nip.io
+      opensearchDashboardsUrl: https://osd.vmi.system.default.11.22.33.44.nip.io
       opensearchUrl: https://opensearch.vmi.system.default.11.22.33.44.nip.io
       prometheusUrl: https://prometheus.vmi.system.default.11.22.33.44.nip.io
       rancherUrl: https://rancher.default.11.22.33.44.nip.io
@@ -110,7 +110,7 @@ The following is an example of the output:
 "keyCloakUrl": "https://keycloak.default.11.22.33.44.nip.io",
 "kialiUrl": "https://kiali.vmi.system.default.11.22.33.44.nip.io",
 "opensearchUrl": "https://opensearch.vmi.system.default.11.22.33.44.nip.io",
-"opensearchDashboardsUrl": "https://opensearchDashboards.vmi.system.default.11.22.33.44.nip.io",
+"opensearchDashboardsUrl": "https://osd.vmi.system.default.11.22.33.44.nip.io",
 "prometheusUrl": "https://prometheus.vmi.system.default.11.22.33.44.nip.io",
 "rancherUrl": "https://rancher.default.11.22.33.44.nip.io"
 "thanosQueryUrl": "https://thanos-query.default.11.22.33.44.nip.io"

--- a/content/en/docs/setup/upgrade/verify.md
+++ b/content/en/docs/setup/upgrade/verify.md
@@ -24,10 +24,10 @@ verrazzano-authproxy-594d8c8dcd-llmlr              2/2     Running   0          
 verrazzano-console-74dbf97fdf-zxvvn                2/2     Running   0          38m
 verrazzano-monitoring-operator-6fcf8484fd-gfkhs    1/1     Running   0          38m
 verrazzano-operator-66c8566f95-8lbs6               1/1     Running   0          38m
-vmi-system-os-master-0                             2/2     Running   0          38m
+vmi-system-es-master-0                             2/2     Running   0          38m
 vmi-system-grafana-799d79648d-wsdp4                2/2     Running   0          38m
 vmi-system-kiali-574c6dd94d-f49jv                  2/2     Running   0          41m
-vmi-system-opensearchDashboards-77f8d998f4-zzvqr   2/2     Running   0          38m
+vmi-system-osd-77f8d998f4-zzvqr   2/2     Running   0          38m
 weblogic-operator-7b447fdb47-wlw64                 2/2     Running   0          42m
 ```
 </div>


### PR DESCRIPTION
We still use es for default nodePool and pod names.