### PR TITLE
VZ-10077.  Update thanos Object Storage example for 1.6

### DIFF
--- a/content/en/docs/observability/monitoring/configure/thanos.md
+++ b/content/en/docs/observability/monitoring/configure/thanos.md
@@ -71,11 +71,11 @@ type: OCI
 config:
   provider: "raw"
   bucket: "thanos"
-  compartment_ocid: ocid1.compartment.oc1.....
-  region: us-ashburn-1
-  tenancy_ocid: ocid1.tenancy.oc1.....
-  user_ocid: ocid1.user.oc1.....
-  fingerprint: 12:d3:4c:gh:fd:9e:27:g8:b9:0d:9f:00:22:33:c3:gg
+  compartment_ocid: "ocid1.compartment.oc1....."
+  region: "us-ashburn-1"
+  tenancy_ocid: "ocid1.tenancy.oc1....."
+  user_ocid: "ocid1.user.oc1....."
+  fingerprint: "12:d3:4c:..."
   key: |
     -----BEGIN RSA PRIVATE KEY-----
     ...

--- a/content/en/docs/observability/monitoring/configure/thanos.md
+++ b/content/en/docs/observability/monitoring/configure/thanos.md
@@ -55,13 +55,13 @@ spec:
 </div>
 {{< /clipboard >}}
 
-## Enable long-term storage
+## Enable long-term storage using OCI Object Storage
 
 Optionally, to enable long-term storage of metrics complete the following steps:
 
 ### Step 1: Create a YAML configuration file
 
-Create a `storage.yaml` file using OCI object storage.
+Create a local file named `storage.yaml` with valid credentials for accessing your bucket in OCI Object Storage.
 
 {{< clipboard >}}
 <div class="highlight">
@@ -70,13 +70,16 @@ Create a `storage.yaml` file using OCI object storage.
 type: OCI
 config:
   provider: "raw"
-  bucket: "<bucket name>"
-  compartment_ocid: "<bucket compartment OCID>"
-  tenancy_ocid: "<tenancy OCID>"
-  user_ocid: "<user OCID>"
-  region: "<region>"
-  fingerprint: ""
-  privatekey: ""
+  bucket: "thanos"
+  compartment_ocid: ocid1.compartment.oc1.....
+  region: us-ashburn-1
+  tenancy_ocid: ocid1.tenancy.oc1.....
+  user_ocid: ocid1.user.oc1.....
+  fingerprint: 12:d3:4c:gh:fd:9e:27:g8:b9:0d:9f:00:22:33:c3:gg
+  key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
 ```
 
 </div>
@@ -84,9 +87,9 @@ config:
 
 ### Step 2: Create a secret
 
-Create the secret for object storage configuration.
+Create the secret for object storage configuration using the `storage.yaml` file you created in Step 1.
 
-The following example uses the file name `storage.yaml`. The Thanos Store Gateway requires the key in the secret to be `objstore.yml`.
+The Thanos Store Gateway requires the key in the secret to be `objstore.yml`.
 
 {{< clipboard >}}
 <div class="highlight">
@@ -101,7 +104,9 @@ $ kubectl create secret generic objstore-config -n verrazzano-monitoring --from-
 
 ### Step 3: Enable storage and Thanos Store Gateway
 
-The following example enables storage, creates the required secret, and enables Thanos Store Gateway. It also configures the Thanos Sidecar to write to object storage and the Store Gateway to read from object storage.
+The following example enables storage, creates the required secret, and enables Thanos Store Gateway in the Verrazzano 
+custom resource. It also configures the Thanos Sidecar to write to object storage and the Store Gateway to read from 
+object storage.
 
 **Note**: `objstore-config` is the secret that you created in Step 2.
 

--- a/content/en/docs/observability/monitoring/configure/thanos.md
+++ b/content/en/docs/observability/monitoring/configure/thanos.md
@@ -57,7 +57,7 @@ spec:
 
 ## Enable long-term storage using OCI Object Storage
 
-Optionally, Thanos can be configured to use [OCI Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm) 
+Optionally, you can configure Thanos to use [OCI Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm) 
 for long-term storage of metrics.
 
 To enable this behavior complete the following steps:

--- a/content/en/docs/observability/monitoring/configure/thanos.md
+++ b/content/en/docs/observability/monitoring/configure/thanos.md
@@ -57,11 +57,15 @@ spec:
 
 ## Enable long-term storage using OCI Object Storage
 
-Optionally, to enable long-term storage of metrics complete the following steps:
+Optionally, Thanos can be configured to use [OCI Object Storage](https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm) 
+for long-term storage of metrics.
+
+To enable this behavior complete the following steps:
 
 ### Step 1: Create a YAML configuration file
 
-Create a local file named `storage.yaml` with valid credentials for accessing your bucket in OCI Object Storage.
+Create a local file named `storage.yaml` that identifies your OCI Object Storage bucket name, the region and compartment
+where it is located within your OCI tenancy, and a valid set of credentials for Thanos to use when accessing it.
 
 {{< clipboard >}}
 <div class="highlight">


### PR DESCRIPTION
Fix up the `storage.yaml` example in the Thanos doc