### PR TITLE
Fix for json-path related errors in some of the docs

### DIFF
--- a/content/en/docs/examples/helidon-config/_index.md
+++ b/content/en/docs/examples/helidon-config/_index.md
@@ -88,7 +88,7 @@ Follow these steps to test the endpoints.
    ```
    $ HOST=$(kubectl get gateways.networking.istio.io helidon-config-helidon-config-appconf-gw \
         -n helidon-config \
-        -o jsonpath={.spec.servers[0].hosts[0]})
+        -o jsonpath='{.spec.servers[0].hosts[0]}')
    $ echo $HOST
 
    # Sample output

--- a/content/en/docs/examples/microservices/sock-shop.md
+++ b/content/en/docs/examples/microservices/sock-shop.md
@@ -128,7 +128,7 @@ Follow these steps to test the endpoints.
    ```
    $ HOST=$(kubectl get gateways.networking.istio.io \
         -n sockshop \
-        -o jsonpath={.items[0].spec.servers[0].hosts[0]})
+        -o jsonpath='{.items[0].spec.servers[0].hosts[0]}')
    $ echo $HOST
 
    # Sample output

--- a/content/en/docs/examples/microservices/spring-boot.md
+++ b/content/en/docs/examples/microservices/spring-boot.md
@@ -79,7 +79,7 @@ This example provides a simple web application developed using [Spring Boot](htt
    ```
    $ HOST=$(kubectl get gateways.networking.istio.io \
         -n springboot \
-        -o jsonpath={.items[0].spec.servers[0].hosts[0]})
+        -o jsonpath='{.items[0].spec.servers[0].hosts[0]}')
    $ echo $HOST
 
    # Sample output


### PR DESCRIPTION
This fixes some syntax issues I noticed that led to the host name not being properly displayed to the user.