### PR TITLE
Fixed url and hugo warning

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -3,8 +3,9 @@
 
 [en]
   title = "Verrazzano Enterprise Container Platform"
-  description = "A hybrid multi-cloud Kubernetes based Enterprise Container Platform for running both cloud-native and traditional applications"
   languageName ="English"
   contentDir = "content/en"
   # Weight used for sorting.
   weight = 1
+[en.params]
+  description = "A hybrid multi-cloud Kubernetes based Enterprise Container Platform for running both cloud-native and traditional applications"

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/IngressInvalidShape.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/IngressInvalidShape.md
@@ -16,4 +16,4 @@ The root cause appears to be that Verrazzano custom resource provided an invalid
 2. Refer to the Oracle Cloud Infrastructure documentation, [Load Balancer Management](https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingloadbalancer.htm#console).
 
 ### Related information
-* [Customize Load Balancers on OKE](https://docs.oracle.com/en/cloud/iaas/verrazzano/vzdoc/docs/customize/ociloadbalancerips/)
+* [Customize Load Balancers on OKE]({{< relref "/docs/networking/traffic/ociloadbalancerips.md" >}})


### PR DESCRIPTION
Fixed url.

Fixed hugo warning seen during execution of make target `hugo`

> WARN  config: languages.en.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120