### PR TITLE
VZ-10071: Add Prometheus storage information and troubleshooting

### DIFF
--- a/content/en/docs/observability/monitoring/configure/prometheus.md
+++ b/content/en/docs/observability/monitoring/configure/prometheus.md
@@ -97,3 +97,36 @@ EOF
 For more information, see [Deploying Prometheus rules](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/alerting.md#deploying-prometheus-rules).
 
 For instructions to customize persistent storage settings, see [Customize Persistent Storage]({{< relref "docs/observability/logging/configure-opensearch/storage.md " >}}).
+
+## Configure data retention settings
+
+Verrazzano configures Prometheus with a default data retention setting of 10 days. The rate of metrics data collected depends on many factors, including the number of monitors, the monitor scrape intervals, and the number of metrics returned by each monitor.
+
+When using persistent storage for Prometheus, it is possible to consume all storage. If Prometheus uses all available persistent storage, then queries return no data and new metrics cannot be saved.
+You can customize the persistent storage settings and change the data retention days and/or configure a maximum retention size. When configuring retention size, a good rule of thumb is to set the value
+to no more than 85% of the persistent storage size.
+
+The following example configures Prometheus to store at most three days or 40GB of metrics data.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+apiVersion: install.verrazzano.io/v1beta1
+kind: Verrazzano
+metadata:
+  name: custom-prometheus
+spec:
+  profile: prod
+  components:
+    prometheusOperator:
+      overrides:
+        - values:
+            prometheus:
+              prometheusSpec:
+                retention: 3d
+                retentionSize: 40GB
+```
+
+</div>
+{{< /clipboard >}}

--- a/content/en/docs/observability/monitoring/configure/prometheus.md
+++ b/content/en/docs/observability/monitoring/configure/prometheus.md
@@ -6,7 +6,9 @@ draft: false
 aliases:
   - /docs/customize/prometheus
 ---
-Prometheus is a system for monitoring cloud native applications and is used by Verrazzano to monitor applications. Prometheus is used in Verrazzano to collect system performance metrics and applications deployed or managed by Verrazzano. Prometheus analysis the metrics and provide a visualization using Grafana.
+Prometheus is a system for monitoring cloud native applications and is used by Verrazzano to monitor applications. Prometheus is used in Verrazzano to collect system performance metrics and metrics for applications deployed or managed by Verrazzano. Prometheus analyzes the metrics and provides visualization using Grafana.
+
+## Customize Prometheus configuration
 
 Verrazzano installs Prometheus components, including Prometheus Operator and Prometheus, using the
 [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart.
@@ -103,10 +105,10 @@ For instructions to customize persistent storage settings, see [Customize Persis
 Verrazzano configures Prometheus with a default data retention setting of 10 days. The rate of metrics data collected depends on many factors, including the number of monitors, the monitor scrape intervals, and the number of metrics returned by each monitor.
 
 When using persistent storage for Prometheus, it is possible to consume all storage. If Prometheus uses all available persistent storage, then queries return no data and new metrics cannot be saved.
-You can customize the persistent storage settings and change the data retention days and/or configure a maximum retention size. When configuring retention size, a good rule of thumb is to set the value
-to no more than 85% of the persistent storage size.
+You can customize the persistent storage settings, and change the data retention days and configure a maximum retention size. When configuring retention size, a good rule of thumb is to set the value
+to no more than 85 percent of the persistent storage size.
 
-The following example configures Prometheus to store at most three days or 40GB of metrics data.
+The following example configures Prometheus to store at most three days or 40 GB of metrics data.
 
 {{< clipboard >}}
 <div class="highlight">

--- a/content/en/docs/observability/monitoring/troubleshooting-prometheus.md
+++ b/content/en/docs/observability/monitoring/troubleshooting-prometheus.md
@@ -104,3 +104,67 @@ spec:
 {{< /clipboard >}}
 
 After you've completed these steps, you can [verify metrics collection]({{< relref "/docs/observability/monitoring/configure-metrics.md#verify-metrics-collection" >}}) has succeeded.
+
+### Metrics queries no longer return metrics
+
+If Prometheus storage reaches capacity, then metrics queries will no longer return results. Check the Prometheus logs.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+kubectl logs -l app.kubernetes.io/instance=prometheus-operator-kube-p-prometheus -n verrazzano-monitoring
+```
+
+</div>
+{{< /clipboard >}}
+
+If there are messages indicating that the disk is full, then it will be necessary to either expand the storage or free disk space. If the default storage class supports volume expansion,
+then you can attempt to expand the volume.
+
+Check if the default storage class allows volume expansion.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+kubectl get storageclass
+```
+
+</div>
+{{< /clipboard >}}
+
+If the default storage class allows expansion, then modify the persistent volume claim and the Prometheus resource storage request to use the larger size.
+
+For example, to increase the storage to 100Gi:
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl patch pvc prometheus-prometheus-operator-kube-p-prometheus-db-prometheus-prometheus-operator-kube-p-prometheus-0 -n verrazzano-monitoring \
+   --type=merge -p '{"spec":{"resources":{"requests":{"storage":"100Gi"}}}}'
+
+$ kubectl patch prometheus prometheus-operator-kube-p-prometheus -n verrazzano-monitoring \
+   --type=merge -p '{"spec":{"storage":{"volumeClaimTemplate":{"spec":{"resources":{"requests":{"storage":"100Gi"}}}}}}}'
+```
+
+</div>
+{{< /clipboard >}}
+
+Alternatively, delete existing metrics data in the Prometheus pods to free space:
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl exec statefulset.apps/prometheus-prometheus-operator-kube-p-prometheus -n verrazzano-monitoring -- rm -fr /prometheus/wal
+
+$ kubectl rollout restart statefulset.apps/prometheus-prometheus-operator-kube-p-prometheus -n verrazzano-monitoring
+```
+
+</div>
+{{< /clipboard >}}
+
+See [Configure data retention settings]({{< relref "/docs/observability/monitoring/configure/prometheus#configure-data-retention-settings" >}}) for information on how to
+configure Prometheus data retention settings to avoid filling up persistent storage in the Prometheus pods.

--- a/content/en/docs/observability/monitoring/troubleshooting-prometheus.md
+++ b/content/en/docs/observability/monitoring/troubleshooting-prometheus.md
@@ -113,7 +113,7 @@ If Prometheus storage reaches capacity, then metrics queries will no longer retu
 <div class="highlight">
 
 ```
-kubectl logs -l app.kubernetes.io/instance=prometheus-operator-kube-p-prometheus -n verrazzano-monitoring
+$ kubectl logs -l app.kubernetes.io/instance=prometheus-operator-kube-p-prometheus -n verrazzano-monitoring
 ```
 
 </div>
@@ -128,7 +128,7 @@ Check if the default storage class allows volume expansion.
 <div class="highlight">
 
 ```
-kubectl get storageclass
+$ kubectl get storageclass
 ```
 
 </div>
@@ -136,7 +136,7 @@ kubectl get storageclass
 
 If the default storage class allows expansion, then modify the persistent volume claim and the Prometheus resource storage request to use the larger size.
 
-For example, to increase the storage to 100Gi:
+For example, to increase the storage to 100 Gi:
 
 {{< clipboard >}}
 <div class="highlight">
@@ -152,7 +152,7 @@ $ kubectl patch prometheus prometheus-operator-kube-p-prometheus -n verrazzano-m
 </div>
 {{< /clipboard >}}
 
-Alternatively, delete existing metrics data in the Prometheus pods to free space:
+Alternatively, delete existing metrics data in the Prometheus pods to free space.
 
 {{< clipboard >}}
 <div class="highlight">
@@ -166,5 +166,5 @@ $ kubectl rollout restart statefulset.apps/prometheus-prometheus-operator-kube-p
 </div>
 {{< /clipboard >}}
 
-See [Configure data retention settings]({{< relref "/docs/observability/monitoring/configure/prometheus#configure-data-retention-settings" >}}) for information on how to
-configure Prometheus data retention settings to avoid filling up persistent storage in the Prometheus pods.
+For information on how to configure Prometheus data retention settings to avoid filling up persistent storage in the Prometheus pods,
+see [Configure data retention settings]({{< relref "/docs/observability/monitoring/configure/prometheus#configure-data-retention-settings" >}}).


### PR DESCRIPTION
This PR adds the following Prometheus information:
1. A section on the Prometheus configuration page that describes how to configure data retention settings
2. A section on the Prometheus troubleshooting page describing how to recover from filling up persistent storage