### PR TITLE
Reset font weight of headers to theme font weight.

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -51,14 +51,6 @@ $orange: $secondary !default;
 
 $lead-font-weight: 400 !default;
 
-.td-content > h1 { font-weight: 700; }
-.td-content > h2 { font-weight: 700; }
-.td-content > h3 { font-weight: 700; }
-.td-content > h4 { font-weight: 700; }
-.td-content > h5 { font-weight: 700; }
-.td-content > h6 { font-weight: 700; }
-.td-content > h7 { font-weight: 700; }
-
 .header-color {
   color: black;
 }


### PR DESCRIPTION
Currently all headers have font-weight: 700 which makes h2, h3 looks awkward.  Reset font weights to theme font weights.

Before:
![font_weight_before](https://github.com/verrazzano/docs/assets/2422580/d013fa8e-62fe-4d01-a9cf-c34cd40bba71)

After:
![font_weight_after](https://github.com/verrazzano/docs/assets/2422580/13c0e810-ea1b-41a3-ab6e-4c6256899725)
