### PR TITLE
VZ-10276: add analyze of KontainerDriver resources

### DIFF
--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
@@ -11,4 +11,5 @@ Analysis detected that a Rancher KontainerDriver resource was not in a ready sta
 A ready KontainerDriver resource will have a status with condition types Active, Downloaded, and Installed set the `True`.
 
 ### Steps
-Review the rancher logs in the cattle-system namespace for additional details.
+Review the rancher logs in the cattle-system namespace for additional details as to why the KontainerDriver resource is
+not ready.

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
@@ -1,0 +1,14 @@
+---
+title: KontainerDriver Resource Not Ready
+linkTitle: KontainerDriver Resource Not Ready
+description: Analysis detected a KontainerDriver resource that is not in a ready state.
+weight: 5
+draft: false
+---
+
+### Summary
+Analysis detected that a Rancher KontainerDriver resource was not in a ready state.
+A ready KontainerDriver resource will have a status with condition types Active, Downloaded, and Installed set the `True`.
+
+### Steps
+Review the rancher logs in the cattle-system namespace for additional details.


### PR DESCRIPTION
This pull request adds a runbook referenced from `vz analyze` for KontainerDriver resources not ready.