### PR TITLE
hide archive page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -6,6 +6,7 @@ menu:
     weight: 20
 no_list: true
 type: list
+draft: true
 ---
 
 Documentation archive of verrazzano.io for each release.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -14,15 +14,15 @@ draft: false
 The timeline for Verrazzano releases and the date of their end of error correction.
 
 
-| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | End of Error Correction  |
-|------------|--------------|----------------------|---------------------------|--------------------------|
-| 1.6        | 2023-06-28   |                      |                           | 2024-06-30*              |
-| 1.5        | 2023-02-15   | 1.5.3                | 2023-05-09                | 2024-02-28               |
-| 1.4        | 2022-09-30   | 1.4.5                | 2023-05-12                | 2023-10-31               |
-| 1.3        | 2022-05-24   | 1.3.8                | 2022-11-17                | 2023-05-31               |
-| 1.2        | 2022-03-14   | 1.2.2                | 2022-05-10                | 2022-11-30               |
-| 1.1        | 2021-12-16   | 1.1.2                | 2022-03-09                | 2022-09-30               |
-| 1.0        | 2021-08-02   | 1.0.4                | 2021-12-20                | 2022-06-30               |
+| Verrazzano                                                                 | Release Date | Latest Patch Release                                                                 | Latest Patch Release Date | End of Error Correction  |
+|----------------------------------------------------------------------------|--------------|--------------------------------------------------------------------------------------|---------------------------|--------------------------|
+| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0)        | 2023-06-28   |                                                                                      |                           | 2024-06-30*              |
+| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0)        | 2023-02-15   | [1.5.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.3)                | 2023-05-09                | 2024-02-28               |
+| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0)        | 2022-09-30   | [1.4.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.5)                | 2023-05-12                | 2023-10-31               |
+| [1.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.0)        | 2022-05-24   | [1.3.8](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.8)                | 2022-11-17                | 2023-05-31               |
+| [1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.0)        | 2022-03-14   | [1.2.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.2)                | 2022-05-10                | 2022-11-30               |
+| [1.1](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.0)        | 2021-12-16   | [1.1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.2)                | 2022-03-09                | 2022-09-30               |
+| [1.0](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.0)        | 2021-08-02   | [1.0.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.4)                | 2021-12-20                | 2022-06-30               |
 
 <br>
 *_Projected date. Actual date will be determined when the next minor or major release is available._

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,3 +8,21 @@ no_list: true
 type: list
 draft: false
 ---
+
+## Release History
+
+The following table shows the timeline for Verrazzano releases and when they reach their EOL date.
+
+
+| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | End of Error Correction* |
+|------------|--------------|----------------------|---------------------------|--------------------------|
+| 1.6        | 2023-06-28   |                      |                           | 2024-06-30**             |
+| 1.5        | 2023-02-15   | 1.5.3                | 2023-05-09                | 2024-02-28               |
+| 1.4        | 2022-09-30   | 1.4.5                | 2023-05-12                | 2023-10-31               |
+| 1.3        | 2022-05-24   | 1.3.8                | 2022-11-17                | 2023-05-31               |
+| 1.2        | 2022-03-14   | 1.2.2                | 2022-05-10                | 2022-11-30               |
+| 1.1        | 2021-12-16   | 1.1.2                | 2022-03-09                | 2022-09-30               |
+| 1.0        | 2021-08-02   | 1.0.4                | 2021-12-20                | 2022-06-30               |
+
+*_End of error correction for Verrazzano releases._<br>
+**_Projected date. Actual date will be determined when the next minor or major release is available._

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -25,4 +25,4 @@ The timeline for Verrazzano releases and the date of their end of error correcti
 | [1.0](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.0)        | 2021-08-02   | [1.0.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.4)                | 2021-12-20                | 2022-06-30               |
 
 <br>
-*_Projected date. Actual date will be determined when the next minor or major release is available._
+*Projected date. Actual date will be determined when the next minor or major release is available.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 weight: 20
-linkTitle: "Release Information"
+linkTitle: "Release History"
 menu:
   main:
     weight: 20
@@ -9,14 +9,14 @@ type: list
 draft: false
 ---
 
-## Release History
-
-The following table shows the timeline for Verrazzano releases and when they reach their EOL date.
 
 
-| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | End of Error Correction* |
+The timeline for Verrazzano releases and the date of their end of error correction.
+
+
+| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | End of Error Correction  |
 |------------|--------------|----------------------|---------------------------|--------------------------|
-| 1.6        | 2023-06-28   |                      |                           | 2024-06-30**             |
+| 1.6        | 2023-06-28   |                      |                           | 2024-06-30*              |
 | 1.5        | 2023-02-15   | 1.5.3                | 2023-05-09                | 2024-02-28               |
 | 1.4        | 2022-09-30   | 1.4.5                | 2023-05-12                | 2023-10-31               |
 | 1.3        | 2022-05-24   | 1.3.8                | 2022-11-17                | 2023-05-31               |
@@ -24,5 +24,5 @@ The following table shows the timeline for Verrazzano releases and when they rea
 | 1.1        | 2021-12-16   | 1.1.2                | 2022-03-09                | 2022-09-30               |
 | 1.0        | 2021-08-02   | 1.0.4                | 2021-12-20                | 2022-06-30               |
 
-*_End of error correction for Verrazzano releases._<br>
-**_Projected date. Actual date will be determined when the next minor or major release is available._
+<br>
+*_Projected date. Actual date will be determined when the next minor or major release is available._

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,19 +1,10 @@
 ---
 weight: 20
-linkTitle: "Documentation Archive"
+linkTitle: "Release Information"
 menu:
   main:
     weight: 20
 no_list: true
 type: list
-draft: true
+draft: false
 ---
-
-Documentation archive of verrazzano.io for each release.
-
-- [v1.6](../../latest/docs) (latest)
-- [v1.5](../../v1.5/docs)
-- [v1.4](../../v1.4/docs)
-- [v1.3](../../v1.3/docs)
-- [v1.2](../../v1.2/docs)
-- [v1.1](../../v1.1/docs)


### PR DESCRIPTION
Hide doc archive page, as per [VZ-9735](https://jira.oraclecorp.com/jira/browse/VZ-9735) Documentation Archive page is no longer needed.