### PR TITLE
remove-x-refs-to-archive-page-VZ-9735

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -55,6 +55,10 @@ url = "https://verrazzano.io/v1.2/docs"
 version = "v1.1"
 url = "https://verrazzano.io/v1.1/docs"
 
+[[params.versions]]
+version = "Release History"
+url = "https://verrazzano.io/archive/docs"
+
 [security]
   [security.exec]
     osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|HOME|SSH_AUTH_SOCK|USERPROFILE|XDG_CONFIG_HOME|HTTP_PROXY|HTTPS_PROXY|NO_PROXY)$']

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -55,10 +55,6 @@ url = "https://verrazzano.io/v1.2/docs"
 version = "v1.1"
 url = "https://verrazzano.io/v1.1/docs"
 
-[[params.versions]]
-version = "Archive"
-url = "https://verrazzano.io/archive/docs"
-
 [security]
   [security.exec]
     osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|HOME|SSH_AUTH_SOCK|USERPROFILE|XDG_CONFIG_HOME|HTTP_PROXY|HTTPS_PROXY|NO_PROXY)$']

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -15,6 +15,6 @@ Learn more about the advantages of using Verrazzano at [Verrazzano Features]({{<
 Select [Quick Start]({{< relref "/docs/setup/quickstart/_index.md" >}}) to get started.
 
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
-This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano.
+This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano. Find the Verrazzano release history [here](https://verrazzano.io/archive/docs).
 
 For documentation from all releases, use the Documentation version menu at the top of this page. For developers' perspectives, read our [blogs](https://medium.com/verrazzano).

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -17,4 +17,4 @@ Select [Quick Start]({{< relref "/docs/setup/quickstart/_index.md" >}}) to get s
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
 This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano.
 
-For documentation from all releases, see the [Documentation Archive](../../archive). For developers' perspectives, read our [blogs](https://medium.com/verrazzano).
+For documentation from all releases, use the Documentation version menu at the top of this page. For developers' perspectives, read our [blogs](https://medium.com/verrazzano).

--- a/content/en/docs/setup/install/prepare/prereqs.md
+++ b/content/en/docs/setup/install/prepare/prereqs.md
@@ -30,18 +30,15 @@ Verrazzano supports the following software versions.
 ### Kubernetes
 You can install Verrazzano on the following Kubernetes versions.
 
-| Verrazzano | Release Date | Latest Patch Release | Latest Patch Release Date | End of Error Correction* | Kubernetes Versions    |
-|------------|--------------|----------------------|---------------------------|--------------------------|------------------------|
-| 1.6        | 2023-06-28   |                      |                           | 2024-06-30**             | 1.24, 1.25, 1.26       |
-| 1.5        | 2023-02-15   | 1.5.3                | 2023-05-09                | 2024-02-28               | 1.21, 1.22, 1.23, 1.24 |
-| 1.4        | 2022-09-30   | 1.4.5                | 2023-05-12                | 2023-10-31               | 1.21, 1.22, 1.23, 1.24 |
-| 1.3        | 2022-05-24   | 1.3.8                | 2022-11-17                | 2023-05-31               | 1.21, 1.22, 1.23       |
-| 1.2        | 2022-03-14   | 1.2.2                | 2022-05-10                | 2022-11-30               | 1.19, 1.20, 1.21       |
-| 1.1        | 2021-12-16   | 1.1.2                | 2022-03-09                | 2022-09-30               | 1.19, 1.20, 1.21       |
-| 1.0        | 2021-08-02   | 1.0.4                | 2021-12-20                | 2022-06-30               | 1.18, 1.19, 1.20       |
-
-*_End of error correction for Verrazzano releases._<br>
-**_Projected date. Actual date will be determined when the next minor or major release is available._
+| Verrazzano | Kubernetes Versions    |
+|------------|------------------------|
+| 1.6        | 1.24, 1.25, 1.26       |
+| 1.5        | 1.21, 1.22, 1.23, 1.24 |
+| 1.4        | 1.21, 1.22, 1.23, 1.24 |
+| 1.3        | 1.21, 1.22, 1.23       |
+| 1.2        | 1.19, 1.20, 1.21       |
+| 1.1        | 1.19, 1.20, 1.21       |
+| 1.0        | 1.18, 1.19, 1.20       |
 
 <br>
 


### PR DESCRIPTION
Remove x-refs to the Archive page from the Doc home page and from the Documentation version menu.