### PR TITLE
VZ-10278: add vz analyze runbook for cluster API resource not ready

### DIFF
--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/ClusterApiClusterNotReady.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/ClusterApiClusterNotReady.md
@@ -1,0 +1,15 @@
+---
+title: Cluster API Resource Not Ready
+linkTitle: Cluster API Resource Not Ready
+description: Analysis detected a Cluster API resource that is not in a ready state.
+weight: 5
+draft: false
+---
+
+### Summary
+Analysis detected that a Cluster API cluster.cluster.x-k8s.io resource was not in a ready state.
+A ready cluster resource will have a status with condition types all set to `True`.
+
+### Steps
+Review the logs in the `verrazzano-capi` namespace for additional details as to why the cluster resource is
+not ready.

--- a/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
+++ b/content/en/docs/troubleshooting/diagnostictools/analysisadvice/KontainerDriverNotReady.md
@@ -8,7 +8,7 @@ draft: false
 
 ### Summary
 Analysis detected that a Rancher KontainerDriver resource was not in a ready state.
-A ready KontainerDriver resource will have a status with condition types Active, Downloaded, and Installed set the `True`.
+A ready KontainerDriver resource will have a status with condition types Active, Downloaded, and Installed set to `True`.
 
 ### Steps
 Review the Rancher logs in the `cattle-system` namespace for additional details as to why the KontainerDriver resource is


### PR DESCRIPTION
This pull request adds a new runbook that is referenced by vz analyze when a cluster API cluster resource is not ready.

When a troubleshooting guide is available for CAPI created clusters this runbook should be updated to refer to that guide.