### PR TITLE
VZ-10297 correct weblogic restart documentation

### DIFF
--- a/content/en/docs/setup/upgrade/prepare.md
+++ b/content/en/docs/setup/upgrade/prepare.md
@@ -18,8 +18,8 @@ images with newer versions.
 If Verrazzano has a new version of Istio, then all the pods with Istio proxy sidecars
 need to be restarted. This is done so that the new version of the proxy sidecar can be injected into the pods.
 All Verrazzano system pods containing Istio proxy sidecars will be restarted.
-Additionally, application workloads with old versions of the Istio proxy sidecar will be restarted as well.
-Verrazzano will perform a rolling restart of all application workloads except WebLogic workloads with an istio proxy sidecar
+Additionally, OAM application workloads with old versions of the Istio proxy sidecar will be restarted as well.
+Verrazzano will perform a rolling restart of all OAM workloads except WebLogic workloads with an istio proxy sidecar
 that is out of date by two minor version or more. For these workloads, Verrazzano will stop the WebLogic Domain prior to upgrade
 and restart it once the upgrade has been completed. This may result in downtime during upgrade for these WebLogic workloads.
-There is no user involvement related to restarting applications; it is done automatically during upgrade.
+There is no user involvement related to restarting OAM applications; it is done automatically during upgrade.

--- a/content/en/docs/setup/upgrade/prepare.md
+++ b/content/en/docs/setup/upgrade/prepare.md
@@ -16,8 +16,10 @@ images with newer versions.
 
 ### Application and system pod restarts
 If Verrazzano has a new version of Istio, then all the pods with Istio proxy sidecars
-need to be restarted.  This is done so that the new version of the proxy sidecar can be injected into the pods.
-All Verrazzano pods containing Istio proxy sidecars will be restarted.  This includes Verrazzano system pods,
-such as the NGINX Ingress Controller, along with Verrazzano applications.  For WebLogic workloads, Verrazzano
-will shut down every domain, do the upgrade, then restart every domain.  For all other workloads, Verrazzano will perform a rolling restart
-when the upgrade has completed.  There is no user involvement related to restarting applications; it is done automatically during upgrade.
+need to be restarted. This is done so that the new version of the proxy sidecar can be injected into the pods.
+All Verrazzano system pods containing Istio proxy sidecars will be restarted.
+Additionally, application workloads with old versions of the Istio proxy sidecar will be restarted as well.
+Verrazzano will perform a rolling restart of all application workloads except WebLogic workloads with an istio proxy sidecar
+that is out of date by two minor version or more. For these workloads, Verrazzano will stop the WebLogic Domain prior to upgrade
+and restart it once the upgrade has been completed. This may result in downtime during upgrade for these WebLogic workloads.
+There is no user involvement related to restarting applications; it is done automatically during upgrade.

--- a/content/en/docs/setup/upgrade/prepare.md
+++ b/content/en/docs/setup/upgrade/prepare.md
@@ -19,7 +19,7 @@ If Verrazzano has a new version of Istio, then all the pods with Istio proxy sid
 need to be restarted. This is done so that the new version of the proxy sidecar can be injected into the pods.
 All Verrazzano system pods containing Istio proxy sidecars will be restarted.
 Additionally, OAM application workloads with old versions of the Istio proxy sidecar will be restarted as well.
-Verrazzano will perform a rolling restart of all OAM workloads except WebLogic workloads with an Istio proxy sidecar
-that is out of date by two minor version or more. For these workloads, Verrazzano will stop the WebLogic Domain prior to upgrade
-and restart it once the upgrade has been completed. This may result in downtime during upgrade for these WebLogic workloads.
+Verrazzano will perform a rolling restart of all OAM workloads, except WebLogic workloads with an Istio proxy sidecar
+that is out of date by two minor versions or more. For these workloads, Verrazzano will stop the WebLogic domain prior to upgrade
+and restart it after the upgrade has been completed. This may result in downtime during upgrade for these WebLogic workloads.
 There is no user involvement related to restarting OAM applications; it is done automatically during upgrade.

--- a/content/en/docs/setup/upgrade/prepare.md
+++ b/content/en/docs/setup/upgrade/prepare.md
@@ -19,7 +19,7 @@ If Verrazzano has a new version of Istio, then all the pods with Istio proxy sid
 need to be restarted. This is done so that the new version of the proxy sidecar can be injected into the pods.
 All Verrazzano system pods containing Istio proxy sidecars will be restarted.
 Additionally, OAM application workloads with old versions of the Istio proxy sidecar will be restarted as well.
-Verrazzano will perform a rolling restart of all OAM workloads except WebLogic workloads with an istio proxy sidecar
+Verrazzano will perform a rolling restart of all OAM workloads except WebLogic workloads with an Istio proxy sidecar
 that is out of date by two minor version or more. For these workloads, Verrazzano will stop the WebLogic Domain prior to upgrade
 and restart it once the upgrade has been completed. This may result in downtime during upgrade for these WebLogic workloads.
 There is no user involvement related to restarting OAM applications; it is done automatically during upgrade.


### PR DESCRIPTION
This change updates the application restart section of Prepare to Upgrade Verrazzano by specifying that weblogic workloads are only stopped for workloads that have an istio sidecar that is at least 2 versions out of date.