### PR TITLE
Change Helm chart links to link to Verrazzano Helm charts (release-1.5)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -57,9 +57,6 @@ offlineSearchSummaryLength = 200
 # Jaeger version number to be used for Jaeger documentation links
 jaeger_doc_version = "1.42"
 
-# Jaeger Operator Helm chart version number
-jaeger_operator_helm_chart_version = "2.41.0"
-
 # Rancher version to be used for Rancher documentation links
 rancher_doc_version = "v2.6"
 

--- a/content/en/docs/observability/monitoring/configure/prometheus.md
+++ b/content/en/docs/observability/monitoring/configure/prometheus.md
@@ -11,7 +11,7 @@ Prometheus is a system for monitoring cloud native applications and is used by V
 ## Customize Prometheus configuration
 
 Verrazzano installs Prometheus components, including Prometheus Operator and Prometheus, using the
-[kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart.
+[kube-prometheus-stack]({{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack %}}) Helm chart.
 You can customize the installation configuration using Helm overrides specified in the
 Verrazzano custom resource. For example, the following Verrazzano custom resource overrides the number of Prometheus replicas.
 {{< clipboard >}}

--- a/content/en/docs/observability/tracing/configure-tracing.md
+++ b/content/en/docs/observability/tracing/configure-tracing.md
@@ -90,7 +90,7 @@ jaeger-verrazzano-managed-cluster   Running   1.34.1    production   opensearch 
 ### Customize Jaeger
 
 Verrazzano installs the Jaeger Operator and Jaeger using the
-[jaeger-operator](https://github.com/jaegertracing/helm-charts/tree/jaeger-operator-{{<jaeger_operator_helm_chart_version>}}/charts/jaeger-operator) Helm chart.
+[jaeger-operator]({{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator %}}) Helm chart.
 Using Helm overrides specified in the Verrazzano custom resource, you can customize the installation configuration.
 For more information about setting component overrides, see [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
 

--- a/layouts/shortcodes/jaeger_operator_helm_chart_version.html
+++ b/layouts/shortcodes/jaeger_operator_helm_chart_version.html
@@ -1,1 +1,0 @@
-{{ .Site.Params.jaeger_operator_helm_chart_version }}


### PR DESCRIPTION
Backport of Helm chart link changes to release-1.5. See https://github.com/verrazzano/docs/pull/1267 for details.

Note that Thanos was introduced in release 1.6 so the Thanos Helm chart link is not included in this PR.