### PR TITLE
Reset font weight of headers to theme font weight

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -51,14 +51,6 @@ $orange: $secondary !default;
 
 $lead-font-weight: 400 !default;
 
-.td-content > h1 { font-weight: 700; }
-.td-content > h2 { font-weight: 700; }
-.td-content > h3 { font-weight: 700; }
-.td-content > h4 { font-weight: 700; }
-.td-content > h5 { font-weight: 700; }
-.td-content > h6 { font-weight: 700; }
-.td-content > h7 { font-weight: 700; }
-
 .header-color {
   color: black;
 }


### PR DESCRIPTION
Mike G: Currently all headers have font-weight: 700 which makes h2, h3 looks awkward. Reset font weights to theme font weights.