### PR TITLE
Backport Fixed jq commands

### DIFF
--- a/content/en/docs/setup/private-registry/private-registry.md
+++ b/content/en/docs/setup/private-registry/private-registry.md
@@ -197,8 +197,7 @@ Oracle Software Delivery Cloud. Follow the respective download instructions:
 
    ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json \
-    | jq -r '.components[].subcomponents[] | select(.name == "rancher")  \
-    | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
+    | jq -r '.components[].subcomponents[] | select(.name == "rancher") | .images[] | select(.image == "rancher-agent") | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}
@@ -209,8 +208,7 @@ Oracle Software Delivery Cloud. Follow the respective download instructions:
 
    ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json \
-    | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher")  \
-    | .images[] | "\(.image):\(.tag)"'
+    | jq -r '.components[].subcomponents[] | select(.name == "additional-rancher") | .images[] | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}
@@ -221,8 +219,7 @@ Oracle Software Delivery Cloud. Follow the respective download instructions:
 
    ```
    $ cat ${DISTRIBUTION_DIR}/manifests/verrazzano-bom.json \
-    | jq -r '.components[].subcomponents[] | select(.name | startswith("capi-"))  \
-    | .images[] | "\(.image):\(.tag)"'
+    | jq -r '.components[].subcomponents[] | select(.name | startswith("capi-")) | .images[] | "\(.image):\(.tag)"'
    ```
 </div>
 {{< /clipboard >}}


### PR DESCRIPTION
- Backport to 1.6 release - Fixed jq commands - "jq command cannot be split into multiple lines, because the whole thing is single-quoted."
- 1.5 release is already fixed via PR 1302.