### PR TITLE
Add example security rules for OCI VCNs

### DIFF
--- a/content/en/docs/setup/install/prepare/platforms/OLCNE/vcn.md
+++ b/content/en/docs/setup/install/prepare/platforms/OLCNE/vcn.md
@@ -33,7 +33,7 @@ See [Security Rules](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts
 
 
 {{< alert title="NOTE" color="primary" >}}
-You can use either Network Security Groups (NSGs) or security lists to add security rules to your VCN. We recommend using NSGs whenever possible. See [Comparison of Security Lists and Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securityrules.htm#comparison) in the OCI documentation.
+You can use either Network Security Groups (NSGs) or security lists to add security rules to your VCN. We recommend using NSGs whenever possible. For more information, see [Comparison of Security Lists and Network Security Groups](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securityrules.htm#comparison) in the OCI documentation.
 {{< /alert >}}
 
 ### Subnet 1: control plane endpoint
@@ -50,7 +50,7 @@ In this subnet, create security rules that cover the following traffic:
 <summary>Security rule examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
-These examples are provided for reference only. Customize your security rules as needed for your environment.
+These examples are provided for reference *only*. Customize your security rules as needed for your environment.
 {{< /alert >}}
 
 #### Egress rules
@@ -69,11 +69,11 @@ These examples are provided for reference only. Customize your security rules as
 
 ### Subnet 2: control plane nodes
 
-A private subnet that houses the control plane nodes that run Kubernetes control plane components such as the API Server and the control plane pods.
+A private subnet that houses the control plane nodes that run Kubernetes control plane components, such as the API Server and the control plane pods.
 
 In this subnet, create security rules that cover the following traffic:
 
-* Egress: node internet access
+* Egress: node Internet access
 * Ingress: east-west traffic, originating from within the VCN
 * Ingress: control plane endpoint to control plane node access on API endpoint
 * Ingress: worker nodes to control plane node access on API endpoint
@@ -89,14 +89,14 @@ In this subnet, create security rules that cover the following traffic:
 <summary>Security rule examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
-These examples are provided for reference only. Customize your security rules as needed for your environment.
+These examples are provided for reference *only*. Customize your security rules as needed for your environment.
 {{< /alert >}}
 
 #### Egress rules
 
 | Destination Type | Destination | Destination Port | Protocol | Description |
 |------------------|-------------|------------------|----------|-------------|
-| CIDR Block       | 0.0.0.0/0   | All              | All      | Control plane node access to the internet to pull images |
+| CIDR Block       | 0.0.0.0/0   | All              | All      | Control plane node access to the Internet to pull images |
 
 #### Ingress rules
 
@@ -131,7 +131,7 @@ In this subnet, create security rules that cover the following traffic:
 <summary>Security rule examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
-These examples are provided for reference only. Customize your security rules as needed for your environment.
+These examples are provided for reference *only*. Customize your security rules as needed for your environment.
 {{< /alert >}}
 
 #### Egress rules
@@ -154,7 +154,7 @@ A private subnet that houses the worker nodes.
 
 In this subnet, create security rules that cover the following traffic:
 
-* Egress: node internet access
+* Egress: node Internet access
 * Ingress: east-west traffic, originating from within the VCN
 * Ingress: SSH traffic
 * Ingress: ICMP path discovery
@@ -169,14 +169,14 @@ In this subnet, create security rules that cover the following traffic:
 <summary>Security rule examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
-These examples are provided for reference only. Customize your security rules as needed for your environment.
+These examples are provided for reference *only*. Customize your security rules as needed for your environment.
 {{< /alert >}}
 
 #### Egress rules
 
 | Destination Type | Destination | Destination Port | Protocol | Description |
 |------------------|-------------|------------------|----------|-------------|
-| CIDR Block       | 0.0.0.0/0   | All              | All      | Worker node access to the internet to pull images |
+| CIDR Block       | 0.0.0.0/0   | All              | All      | Worker node access to the Internet to pull images |
 
 #### Ingress rules
 
@@ -198,19 +198,19 @@ These examples are provided for reference only. Customize your security rules as
 
 Gateways control access from your VCN to other networks. You'll need to configure three different types of gateways:
 
-* [An internet gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingIGs.htm)
+* [An Internet gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingIGs.htm)
 * [A NAT gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/NATgateway.htm#NAT_Gateway)
 * [A service gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/servicegateway.htm#Access_to_Oracle_Services_Service_Gateway)
 
-You may need to perform some additional configuration to expose the VCN's subnets directly to the internet. See [Access to the Internet](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/overview.htm#Private) in the OCI documentation for details.
+You may need to perform some additional configuration to expose the VCN's subnets directly to the Internet. See [Access to the Internet](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/overview.htm#Private) in the OCI documentation for details.
 
 ## Route tables
 
-Route tables send traffic out of the VCN (for example, to the internet, to your on-premises network, or to a peered VCN) using rules that are similar to traditional network route rules.
+Route tables send traffic out of the VCN (for example, to the Internet, to your on-premises network, or to a peered VCN) using rules that are similar to traditional network route rules.
 
 See [VCN Route Tables](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingroutetables.htm#Route2) in the OCI documentation for more information.
 
 For OCNE clusters, you'll need to create two route tables:
 
-1. A route table for public subnets that will route stateful traffic to and from the internet gateway. Assign this route table to *both* public subnets.
+1. A route table for public subnets that will route stateful traffic to and from the Internet gateway. Assign this route table to *both* public subnets.
 1. A route table for private subnets that will route stateful traffic to and from the NAT and service gateways. Assign this route table to *both* private subnets.

--- a/content/en/docs/setup/install/prepare/platforms/OLCNE/vcn.md
+++ b/content/en/docs/setup/install/prepare/platforms/OLCNE/vcn.md
@@ -47,7 +47,7 @@ In this subnet, create security rules that cover the following traffic:
 * Ingress: ICMP path discovery
 
 <details>
-<summary>Security rule examples</summary>
+<summary>Security rules examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
 These examples are provided for reference *only*. Customize your security rules as needed for your environment.
@@ -86,7 +86,7 @@ In this subnet, create security rules that cover the following traffic:
     * IP-in-IP
 
 <details>
-<summary>Security rule examples</summary>
+<summary>Security rules examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
 These examples are provided for reference *only*. Customize your security rules as needed for your environment.
@@ -128,7 +128,7 @@ In this subnet, create security rules that cover the following traffic:
 * Ingress: HTTP and HTTPS traffic
 
 <details>
-<summary>Security rule examples</summary>
+<summary>Security rules examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
 These examples are provided for reference *only*. Customize your security rules as needed for your environment.
@@ -166,7 +166,7 @@ In this subnet, create security rules that cover the following traffic:
 * Ingress: worker nodes to default NodePort ingress
 
 <details>
-<summary>Security rule examples</summary>
+<summary>Security rules examples</summary>
 
 {{< alert title="NOTE" color="primary" >}}
 These examples are provided for reference *only*. Customize your security rules as needed for your environment.

--- a/content/en/docs/troubleshooting/troubleshooting-clusterapi.md
+++ b/content/en/docs/troubleshooting/troubleshooting-clusterapi.md
@@ -104,7 +104,7 @@ Causes may include:
 
 * OCI resource limits were reached: Cluster creation will fail if it needs to create more resources than allowed by your OCI tenancy. Check your OCI service limits to see if you exceeded its limits. If you need to request a service limit increase, see [Requesting a Service Limit Increase](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/servicelimits.htm#Requesti).
 
-* Connectivity issues: Make sure your virtual cloud network is configured properly.
+* Connectivity issues: Make sure your virtual cloud network is configured properly. See [Configure a VCN for OCNE]({{< relref "/docs/setup/install/prepare/platforms/olcne/vcn" >}}) for recommendations.
 
 * The network load balancer is in a critical state: The network load balancer may temporarily enter a critical state during initial cluster creation until the Kubernetes API server is up. If it remains in a critical state, then one of the following issues may have occurred:
     * Traffic between the network load balancer and the OCNE control plane node is blocked over port 6443.


### PR DESCRIPTION
To hopefully make it clear that these are examples and shouldn't be copied wholesale, I've put the tables in sections that are collapsed by default. If you think that's too hidden, let me know.