### PR TITLE
Move Customize Persistent Storage doc

### DIFF
--- a/content/en/docs/observability/monitoring/configure/prometheus.md
+++ b/content/en/docs/observability/monitoring/configure/prometheus.md
@@ -39,7 +39,7 @@ For more information about setting component overrides, see [Installation Overri
 
 For information about all the overrides supported by the kube-prometheus-stack chart in Verrazzano, see [values.yaml](https://github.com/verrazzano/verrazzano/blob/master/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml).
 
-For instructions to customize persistent storage settings for Prometheus, see [Customize Persistent Storage]({{< relref "docs/observability/logging/configure-opensearch/storage.md " >}}).
+For instructions to customize persistent storage settings for Prometheus, see [Customize Persistent Storage]({{< relref "docs/observability/storage.md " >}}).
 
 ## Configure Alertmanager
 

--- a/content/en/docs/observability/storage.md
+++ b/content/en/docs/observability/storage.md
@@ -1,11 +1,12 @@
 ---
 title: Customize Persistent Storage
 description: Customize persistent storage settings
-Weight: 11
+Weight: 4
 draft: false
 aliases:
   - /docs/customize/storage
   - /docs/setup/customizing/storage
+  - /docs/observability/logging/configure-opensearch/storage
 ---
 
 The following components can use persistent storage:

--- a/content/en/docs/security/keycloak/keycloak.md
+++ b/content/en/docs/security/keycloak/keycloak.md
@@ -13,4 +13,4 @@ Directly modifying the StatefulSet may change the status of the cluster to `ONLI
 may result in the [MySQL Operator]({{< relref "docs/reference/vpo-verrazzano-v1beta1.md#install.verrazzano.io/v1beta1.MySQLOperatorComponent" >}}) permanently losing communication with the cluster and Keycloak being unable to communicate with MySQL.
 * There are limitations to MySQL group replication policy to provide distributed coordination between servers. See [MySQL Fault-tolerance](https://dev.mysql.com/doc/refman/8.0/en/group-replication-fault-tolerance.html).
 
-For instructions to customize persistent storage settings, see [Customize Persistent Storage]({{< relref "docs/observability/logging/configure-opensearch/storage.md " >}}).
+For instructions to customize persistent storage settings, see [Customize Persistent Storage]({{< relref "docs/observability/storage.md " >}}).


### PR DESCRIPTION
As per VZ-10469 Customizing OpenSearch Persistence Page Not about OpenSearch, moved Customize Persistent Storage to a standalone location within Observability section.