### PR TITLE
Backport 1.1 - VZ-10505: Added Support/Help page (#1352)

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -23,6 +23,6 @@ Verrazzano includes the following capabilities:
 Select [Quick Start]({{< relref "/docs/quickstart/_index.md" >}}) to get started.
 
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
-This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano. Find the Verrazzano release history [here](https://verrazzano.io/archive/docs).
+This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano. Find the Verrazzano release history [here]({{< relref "/docs/help/_index.md" >}}).
 
-For documentation from all releases, use the Documentation version menu at the top of this page. For developers' perspectives, read our [blogs](https://medium.com/verrazzano).
+For documentation from all releases, use the Documentation version menu at the top of this page. For developers' perspectives, [check us out on Medium](https://medium.com/verrazzano).

--- a/content/en/docs/help/_index.md
+++ b/content/en/docs/help/_index.md
@@ -1,0 +1,30 @@
+---
+title: Get Help
+weight: 3
+draft: false
+---
+
+See the following support information, learning channels, and Verrazzano release history:
+
+* Verrazzano Community Support - [Join Verrazzano on Slack!](https://bit.ly/verrazzano-slack)
+* [Verrazzano GitHub Project](https://github.com/verrazzano/verrazzano/issues)
+* [Oracle Verrazzano Enterprise Container Platform Support](https://support.oracle.com/epmos/faces/DocumentDisplay?id=2794708) (available for purchase; contact [Oracle Sales](https://www.oracle.com/corporate/contact/))
+* [Check us out on Medium](https://medium.com/verrazzano)
+* [Learn about Verrazzano on YouTube](https://www.youtube.com/@verrazzano_io)
+
+
+<b>Release History & Error Correction Dates<b>
+
+The timeline for Verrazzano releases and the date of their end of error correction.
+| Verrazzano                                                          | Release Date | Latest Patch Release                                                  | Latest Patch Release Date | End of Error Correction |
+|---------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|---------------------------|-------------------------|
+| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.3) | 2023-08-02                | 2024-06-30*             |
+| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.5) | 2023-08-02                | 2024-02-28              |
+| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.6) | 2023-07-31                | 2023-10-31              |
+| [1.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.0) | 2022-05-24   | [1.3.8](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.8) | 2022-11-17                | 2023-05-31              |
+| [1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.0) | 2022-03-14   | [1.2.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.2) | 2022-05-10                | 2022-11-30              |
+| [1.1](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.0) | 2021-12-16   | [1.1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.2) | 2022-03-09                | 2022-09-30              |
+| [1.0](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.0) | 2021-08-02   | [1.0.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.4) | 2021-12-20                | 2022-06-30              |
+
+*Projected date. Actual date will be determined when the next minor or major release is available.
+<br>


### PR DESCRIPTION
- Backport to 1.1 release 
- Updated as per VZ-10505.