### PR TITLE
Update note about VCN native pod networking

### DIFF
--- a/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
+++ b/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
@@ -27,7 +27,7 @@ aliases:
 {{< alert title="NOTE" color="primary" >}} OCI VCN-Native Pod Networking is now supported with Verrazzano for Kubernetes v1.26 and up. 
 The pod network must be in a private subnet to enable egress.
 Either place the worker nodes in a private subnet, or place the pod network in a private subnet separate from the worker nodes.
-For Kubernetes v1.25 and below, use the flannel overlay network.
+For Kubernetes v1.25 and below, you must use the flannel overlay network.
 {{< /alert >}}
 
 ## Next steps

--- a/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
+++ b/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
@@ -24,10 +24,11 @@ aliases:
 
 **NOTE**: Verrazzano can create network policies that can be used to limit the ports and protocols that pods use for network communication. Network policies provide additional security but they are enforced only if you install a Kubernetes Container Network Interface (CNI) plug-in that enforces them, such as Calico. For an example on OKE, see [Installing Calico and Setting Up Network Policies](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengsettingupcalico.htm).
 
-{{< alert title="NOTE" color="primary" >}} OCI VCN-Native Pod Networking is now supported with Verrazzano for Kubernetes v1.26 and up. 
+{{< alert title="NOTE" color="primary" >}} [OCI VCN-Native Pod Networking](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-OCI_CNI_plugin.htm)
+is now supported with Verrazzano for Kubernetes v1.26 and later. 
 The pod network must be in a private subnet to enable egress.
 Either place the worker nodes in a private subnet, or place the pod network in a private subnet separate from the worker nodes.
-For Kubernetes v1.25 and below, you must use the flannel overlay network.
+For Kubernetes v1.25 and earlier, you must use the flannel overlay network.
 {{< /alert >}}
 
 ## Next steps

--- a/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
+++ b/content/en/docs/setup/install/prepare/platforms/OCI/OCI.md
@@ -24,7 +24,10 @@ aliases:
 
 **NOTE**: Verrazzano can create network policies that can be used to limit the ports and protocols that pods use for network communication. Network policies provide additional security but they are enforced only if you install a Kubernetes Container Network Interface (CNI) plug-in that enforces them, such as Calico. For an example on OKE, see [Installing Calico and Setting Up Network Policies](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengsettingupcalico.htm).
 
-{{< alert title="NOTE" color="primary" >}} OKE clusters using only the flannel overlay network is supported. OCI VCN-Native Pod Networking will not work.
+{{< alert title="NOTE" color="primary" >}} OCI VCN-Native Pod Networking is now supported with Verrazzano for Kubernetes v1.26 and up. 
+The pod network must be in a private subnet to enable egress.
+Either place the worker nodes in a private subnet, or place the pod network in a private subnet separate from the worker nodes.
+For Kubernetes v1.25 and below, use the flannel overlay network.
 {{< /alert >}}
 
 ## Next steps


### PR DESCRIPTION
VCN native pod networking is now supported for Verrazzano. Update the note in the OKE platform setup docs.