### PR TITLE
VZ-10560 Add information on Kubernetes upgrades with Verrazzano

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -69,6 +69,9 @@ capoci_version = "0.9.0"
 # CAPOCNE release version
 capocne_version = "1.6.1"
 
+# disable the default click to copy feature
+disable_click2copy_chroma = true
+
 # User interface configuration
 [ui]
 # Enable to show the side bar menu in its compact state.

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -47,7 +47,6 @@ kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --ty
 Rancher spins up Helm pods for cluster operations.
 Because these pods are not managed by any parent resources, they can prevent the node from being drained.
 If this is the case, you can delete these pods with the following command.
-This must be done for each Rancher Helm pod.
 
 ```shell
 kubectl get pods --no-headers=true -n cattle-system | awk '{print $1}' | grep helm | xargs kubectl delete pod --ignore-not-found -n cattle-system

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -1,0 +1,38 @@
+---
+title: "Upgrade Kubernetes with Verrazzano"
+description: "Upgrade the Kubernetes version with a Verrazzano installation"
+weight: 8
+draft: false
+---
+
+After Verrazzano is installed onto a cluster, you may want to upgrade the Kubernetes version of that cluster.
+The following list links to documentation sources for Kubernetes cluster updates.
+Consult your cluster provider's upgrade documentation if it does not appear on this list.
+- [OKE Kubernetes Upgrade](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm).
+- [OLCNE Kubernetes Upgrade](https://docs.oracle.com/en/operating-systems/olcne/1.5/upgrade/update.html#update).
+- [kubeadm Kubernetes Upgrade](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+
+## Upgrading a single node cluster
+
+For a typical multi-node Kubernetes cluster, it is recommended to keep one or more nodes present and available while upgrading nodes.
+However, for a single node cluster, this is not possible.
+For this reason, there are a few manual workarounds that may need be done to be able to fully drain the Kubernetes node.
+
+### Disable the MySQL pod disruption budget
+The MySQL Operator deploys a [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
+for the MySQL database pods. 
+This Pod Disruption Budget will prevent the node from being drained.
+To prevent this, you can patch the Pod Disruption budget to allow the MySQL replicas to be drained from the node.
+
+```shell
+kubectl patch poddisruptionbudgets.policy -n keycloak mysql-pdb -p '{"spec":{"minAvailable":0, "maxUnavailable":null}}' --type=merge
+```
+
+### Remove the MySQL pod finalizers
+It is possible that the MySQL pods will be stuck in the `Terminating` state while the node is being drained.
+If you find that the MySQL pod will not complete termination, you can remove the finalizers to manually terminate these pods.
+
+```shell
+kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --type=merge
+```
+

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -6,6 +6,8 @@ draft: false
 ---
 
 After Verrazzano is installed onto a cluster, you may want to upgrade the Kubernetes version of that cluster.
+Refer to the [Prerequisites]({{< relref "/docs/setup/install/prepare/prereqs.md#kubernetes" >}}) 
+document for more information on the Kubernetes versions that Verrazzano supports.
 The following list links to documentation sources for Kubernetes cluster updates.
 Consult your cluster provider's upgrade documentation if it does not appear on this list.
 - [OKE Kubernetes Upgrade](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm).
@@ -41,3 +43,12 @@ If you find that the MySQL pod will not complete termination, you can remove the
 kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --type=merge
 ```
 
+### Delete the Rancher Helm pods
+Rancher spins up Helm pods for cluster operations.
+Because these pods are not managed by any parent resources, they can prevent the node from being drained.
+If this is the case, you can delete these pods with the following command.
+This must be done for each Rancher Helm pod.
+
+```shell
+kubectl delete pod -n cattle-system helm-operation-12345
+```

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -1,35 +1,35 @@
 ---
-title: "Upgrade Kubernetes with Verrazzano"
-description: "Upgrade the Kubernetes version with a Verrazzano installation"
+title: "Upgrade Kubernetes with Verrazzano installed"
+description: ""
 weight: 8
 draft: false
 ---
 
-After Verrazzano is installed onto a cluster, you may want to upgrade the Kubernetes version of that cluster.
-Refer to the [Prerequisites]({{< relref "/docs/setup/install/prepare/prereqs.md#kubernetes" >}}) 
-document for more information on the Kubernetes versions that Verrazzano supports.
-The following list links to documentation sources for Kubernetes cluster updates.
-Consult your cluster provider's upgrade documentation if it does not appear on this list.
-- [OKE Kubernetes Upgrade](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm).
-- [OLCNE Kubernetes Upgrade](https://docs.oracle.com/en/operating-systems/olcne/1.5/upgrade/update.html#update).
-- [kubeadm Kubernetes Upgrade](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+After Verrazzano is installed in a cluster, you may want to upgrade the Kubernetes version of that cluster.
+For information on the Kubernetes versions that Verrazzano supports, see the [Prerequisites]({{< relref "/docs/setup/install/prepare/prereqs.md#kubernetes" >}}).
 
-## Upgrading a multi-node cluster
+The following lists documentation sources for Kubernetes cluster updates.
+If yours does not appear on this list, then consult your cluster provider's upgrade documentation.
+- [OKE Kubernetes Upgrade](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8smasternode.htm)
+- [OLCNE Kubernetes Upgrade](https://docs.oracle.com/en/operating-systems/olcne/1.5/upgrade/update.html#update)
+- [kubeadm Kubernetes Upgrade](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
 
-For a typical multi-node Kubernetes cluster, it is recommended to keep one or more nodes present and available while upgrading nodes.
-This allows the cordoned nodes to distribute the pods to available nodes to eliminate downtime during an upgrade.
-Your cluster provider should have information on maintaining node availability for an in-place upgrade.
+## Upgrade a multinode cluster
 
-## Upgrading a single node cluster
+For a typical multinode Kubernetes cluster, we recommend keeping one or more nodes present and available while upgrading nodes.
+This allows the cordoned nodes to distribute the pods to available nodes, which eliminates downtime during an upgrade.
+Your cluster provider can provide information on maintaining node availability for an in-place upgrade.
 
-For a single node cluster upgrade, there will be downtime in the cluster to allow the node to cordon while it is upgraded.
-For this reason, there are a few manual workarounds that may need be done to be able to fully drain the Kubernetes node.
+## Upgrade a single-node cluster
+
+For a single-node cluster upgrade, there will be downtime in the cluster to allow the node to cordon while it is upgraded.
+For this reason, there are a few manual workaround steps that you may need to perform to be able to fully drain the Kubernetes node.
 
 ### Disable the MySQL pod disruption budget
 The MySQL Operator deploys a [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
-for the MySQL database pods. 
+for the MySQL database pods.
 This Pod Disruption Budget will prevent the node from being drained.
-To prevent this, you can patch the Pod Disruption budget to allow the MySQL replicas to be drained from the node.
+To change this, you can patch the Pod Disruption budget to allow the MySQL replicas to be drained from the node.
 
 ```shell
 kubectl patch poddisruptionbudgets.policy -n keycloak mysql-pdb -p '{"spec":{"minAvailable":0, "maxUnavailable":null}}' --type=merge
@@ -37,7 +37,7 @@ kubectl patch poddisruptionbudgets.policy -n keycloak mysql-pdb -p '{"spec":{"mi
 
 ### Remove the MySQL pod finalizers
 It is possible that the MySQL pods will be stuck in the `Terminating` state while the node is being drained.
-If you find that the MySQL pod will not complete termination, you can remove the finalizers to manually terminate these pods.
+If you find that the MySQL pod will not complete termination, then you can remove the finalizers to manually terminate these pods.
 
 ```shell
 kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --type=merge
@@ -46,7 +46,7 @@ kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --ty
 ### Delete the Rancher Helm pods
 Rancher spins up Helm pods for cluster operations.
 Because these pods are not managed by any parent resources, they can prevent the node from being drained.
-If this is the case, you can delete these pods with the following command.
+If this is the case, then you can delete these pods with the following command.
 
 ```shell
 kubectl get pods --no-headers=true -n cattle-system | awk '{print $1}' | grep helm | xargs kubectl delete pod --ignore-not-found -n cattle-system

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -50,5 +50,5 @@ If this is the case, you can delete these pods with the following command.
 This must be done for each Rancher Helm pod.
 
 ```shell
-kubectl delete pod -n cattle-system helm-operation-12345
+kubectl get pods --no-headers=true -n cattle-system | awk '{print $1}' | grep helm | xargs kubectl delete pod --ignore-not-found -n cattle-system
 ```

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -12,10 +12,15 @@ Consult your cluster provider's upgrade documentation if it does not appear on t
 - [OLCNE Kubernetes Upgrade](https://docs.oracle.com/en/operating-systems/olcne/1.5/upgrade/update.html#update).
 - [kubeadm Kubernetes Upgrade](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
 
-## Upgrading a single node cluster
+## Upgrading a multi-node cluster
 
 For a typical multi-node Kubernetes cluster, it is recommended to keep one or more nodes present and available while upgrading nodes.
-However, for a single node cluster, this is not possible.
+This allows the cordoned nodes to distribute the pods to available nodes to eliminate downtime during an upgrade.
+Your cluster provider should have information on maintaining node availability for an in-place upgrade.
+
+## Upgrading a single node cluster
+
+For a single node cluster upgrade, there will be downtime in the cluster to allow the node to cordon while it is upgraded.
 For this reason, there are a few manual workarounds that may need be done to be able to fully drain the Kubernetes node.
 
 ### Disable the MySQL pod disruption budget

--- a/content/en/docs/setup/upgrade/kubernetes-upgrade.md
+++ b/content/en/docs/setup/upgrade/kubernetes-upgrade.md
@@ -31,23 +31,41 @@ for the MySQL database pods.
 This Pod Disruption Budget will prevent the node from being drained.
 To change this, you can patch the Pod Disruption budget to allow the MySQL replicas to be drained from the node.
 
-```shell
-kubectl patch poddisruptionbudgets.policy -n keycloak mysql-pdb -p '{"spec":{"minAvailable":0, "maxUnavailable":null}}' --type=merge
+{{< clipboard >}}
+<div class="highlight">
+
 ```
+$ kubectl patch poddisruptionbudgets.policy -n keycloak mysql-pdb -p '{"spec":{"minAvailable":0, "maxUnavailable":null}}' --type=merge
+```
+
+</div>
+{{< /clipboard >}}
 
 ### Remove the MySQL pod finalizers
 It is possible that the MySQL pods will be stuck in the `Terminating` state while the node is being drained.
 If you find that the MySQL pod will not complete termination, then you can remove the finalizers to manually terminate these pods.
 
-```shell
-kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --type=merge
+{{< clipboard >}}
+<div class="highlight">
+
 ```
+$ kubectl patch pod -n keycloak mysql-0 -p '{"metadata":{"finalizers":null}}' --type=merge
+```
+
+</div>
+{{< /clipboard >}}
 
 ### Delete the Rancher Helm pods
 Rancher spins up Helm pods for cluster operations.
 Because these pods are not managed by any parent resources, they can prevent the node from being drained.
 If this is the case, then you can delete these pods with the following command.
 
-```shell
-kubectl get pods --no-headers=true -n cattle-system | awk '{print $1}' | grep helm | xargs kubectl delete pod --ignore-not-found -n cattle-system
+{{< clipboard >}}
+<div class="highlight">
+
 ```
+$ kubectl get pods --no-headers=true -n cattle-system | awk '{print $1}' | grep helm | xargs kubectl delete pod --ignore-not-found -n cattle-system
+```
+
+</div>
+{{< /clipboard >}}


### PR DESCRIPTION
This PR addresses customer issues with a single node upgrade on OLCNE with Verrazzano installed. With these steps, users should be able to drain and upgrade single node clusters. I have also provided a small amount of info on multi-node clusters, but most of that information is covered in the linked documentation.