### PR TITLE
Update RH table

### DIFF
--- a/content/en/docs/support/_index.md
+++ b/content/en/docs/support/_index.md
@@ -18,9 +18,9 @@ See the following support information, learning channels, and Verrazzano release
 The timeline for Verrazzano releases and the date of their end of error correction.
 | Verrazzano                                                          | Release Date | Latest Patch Release                                                  | Latest Patch Release Date | End of Error Correction |
 |---------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|---------------------------|-------------------------|
-| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.5) | 2023-08-28                | 2024-06-30*             |
-| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.5) | 2023-08-02                | 2024-02-28              |
-| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.6) | 2023-07-31                | 2023-10-31              |
+| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.5) | 2023-08-29                | 2024-06-30*             |
+| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.6) | 2023-08-29                | 2024-02-28              |
+| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.7](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.7) | 2023-08-29                | 2023-10-31              |
 | [1.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.0) | 2022-05-24   | [1.3.8](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.8) | 2022-11-17                | 2023-05-31              |
 | [1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.0) | 2022-03-14   | [1.2.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.2) | 2022-05-10                | 2022-11-30              |
 | [1.1](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.0) | 2021-12-16   | [1.1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.2) | 2022-03-09                | 2022-09-30              |


### PR DESCRIPTION
Update the Release History table for the 1.6.5, 1.5.6, and 1.4.7 releases in the 1.2 docs.