### PR TITLE
Update RH table on archive branch

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 weight: 20
-linkTitle: "Release History"
+linkTitle: "Release History & Error Correction Dates"
 menu:
   main:
     weight: 20
@@ -13,17 +13,15 @@ draft: false
 
 The timeline for Verrazzano releases and the date of their end of error correction.
 
-
 | Verrazzano                                                          | Release Date | Latest Patch Release                                                  | Latest Patch Release Date | End of Error Correction |
 |---------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|---------------------------|-------------------------|
-| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.3) | 2023-08-02                | 2024-06-30*             |
-| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.5) | 2023-08-02                | 2024-02-28              |
-| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.6) | 2023-07-31                | 2023-10-31              |
+| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.5) | 2023-08-29                | 2024-06-30*             |
+| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.6) | 2023-08-29                | 2024-02-28              |
+| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.7](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.7) | 2023-08-29                | 2023-10-31              |
 | [1.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.0) | 2022-05-24   | [1.3.8](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.8) | 2022-11-17                | 2023-05-31              |
 | [1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.0) | 2022-03-14   | [1.2.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.2) | 2022-05-10                | 2022-11-30              |
 | [1.1](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.0) | 2021-12-16   | [1.1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.2) | 2022-03-09                | 2022-09-30              |
 | [1.0](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.0) | 2021-08-02   | [1.0.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.4) | 2021-12-20                | 2022-06-30              |
-
 
 *Projected date. Actual date will be determined when the next minor or major release is available.
 <br>


### PR DESCRIPTION
After discussion with Dave C, Will Lyons, and the doc team, we decided to put the Release History table back on the archive branch so that it can be updated in one location and linked to from all previous doc releases. The latest doc release will retain this table (and it will be updated) in its current location on the Support Information page.