### PR TITLE
Update link to RH table

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -15,6 +15,6 @@ Learn more about the advantages of using Verrazzano at [Verrazzano Features]({{<
 Select [Quick Start]({{< relref "/docs/setup/quickstart/_index.md" >}}) to get started.
 
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
-This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano. Find the Verrazzano release history [here]({{< relref "/docs/support/_index.md" >}}).
+This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano. Find the Verrazzano release history [here](https://verrazzano.io/archive/docs).
 
 For documentation from all releases, use the Documentation version menu at the top of this page. For developers' perspectives, [check us out on Medium](https://medium.com/verrazzano).

--- a/content/en/docs/support/_index.md
+++ b/content/en/docs/support/_index.md
@@ -15,16 +15,4 @@ See the following support information, learning channels, and Verrazzano release
 
 <b>Release History & Error Correction Dates<b>
 
-The timeline for Verrazzano releases and the date of their end of error correction.
-| Verrazzano                                                          | Release Date | Latest Patch Release                                                  | Latest Patch Release Date | End of Error Correction |
-|---------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|---------------------------|-------------------------|
-| [1.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.0) | 2023-06-28   | [1.6.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.6.5) | 2023-08-29                | 2024-06-30*             |
-| [1.5](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.0) | 2023-02-15   | [1.5.6](https://github.com/verrazzano/verrazzano/releases/tag/v1.5.6) | 2023-08-29                | 2024-02-28              |
-| [1.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.0) | 2022-09-30   | [1.4.7](https://github.com/verrazzano/verrazzano/releases/tag/v1.4.7) | 2023-08-29                | 2023-10-31              |
-| [1.3](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.0) | 2022-05-24   | [1.3.8](https://github.com/verrazzano/verrazzano/releases/tag/v1.3.8) | 2022-11-17                | 2023-05-31              |
-| [1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.0) | 2022-03-14   | [1.2.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.2.2) | 2022-05-10                | 2022-11-30              |
-| [1.1](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.0) | 2021-12-16   | [1.1.2](https://github.com/verrazzano/verrazzano/releases/tag/v1.1.2) | 2022-03-09                | 2022-09-30              |
-| [1.0](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.0) | 2021-08-02   | [1.0.4](https://github.com/verrazzano/verrazzano/releases/tag/v1.0.4) | 2021-12-20                | 2022-06-30              |
-
-*Projected date. Actual date will be determined when the next minor or major release is available.
-<br>
+For the timeline of Verrazzano releases and the date of their end of error correction, see the Release History table [here](https://verrazzano.io/archive/docs).


### PR DESCRIPTION
Change to the Support Information page to x-ref the Release History table on the archive branch. 