### PR TITLE
VZ-11099 regenerate the API reference to include helm chart links

### DIFF
--- a/content/en/docs/reference/vao-clusters-v1alpha1.md
+++ b/content/en/docs/reference/vao-clusters-v1alpha1.md
@@ -1734,7 +1734,7 @@ ProjectTemplate
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>89eacc2de</code>.
+on git commit <code>906e8361e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vao-oam-v1alpha1.md
+++ b/content/en/docs/reference/vao-oam-v1alpha1.md
@@ -2126,7 +2126,7 @@ structs.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>89eacc2de</code>.
+on git commit <code>906e8361e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vco-clusters-v1alpha1.md
+++ b/content/en/docs/reference/vco-clusters-v1alpha1.md
@@ -90,7 +90,7 @@ NamespacedRef
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>Reference for cloud authentication.</p>
 </td>
@@ -106,7 +106,7 @@ PrivateRegistry
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>Private Registry settings for the workload cluster.</p>
 </td>
@@ -122,7 +122,7 @@ Proxy
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>HTTP Proxy settings.</p>
 </td>
@@ -829,7 +829,7 @@ ClusterNetwork
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.KubernetesBase">KubernetesBase</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.KubernetesBase">KubernetesBase</a>. Inlined comments are appended below.)
 </p>
 <p>Kubernetes network settings.</p>
 </td>
@@ -900,7 +900,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>. Inlined comments are appended below.)
 </p>
 <p>Node pool Shape.</p>
 </td>
@@ -914,7 +914,7 @@ int
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>. Inlined comments are appended below.)
 </p>
 <p>Number of OCPUs per node, when using flex shapes.</p>
 </td>
@@ -928,7 +928,7 @@ int
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>. Inlined comments are appended below.)
 </p>
 <p>Amount of memory per node, in gigabytes, when using flex shapes.</p>
 </td>
@@ -942,7 +942,7 @@ int
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>. Inlined comments are appended below.)
 </p>
 <p>Size of node boot volume, in gigabytes.</p>
 </td>
@@ -956,7 +956,7 @@ int
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.OCINode">OCINode</a>. Inlined comments are appended below.)
 </p>
 <p>Number of nodes to create.</p>
 </td>
@@ -1079,7 +1079,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>OCI region where the cluster will be created.</p>
 </td>
@@ -1093,7 +1093,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>OCI Compartment OCID where the cluster will be created</p>
 </td>
@@ -1107,7 +1107,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>SSH public key for node ssh.</p>
 </td>
@@ -1121,7 +1121,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>Node image OCID.
 The default is the latest OL8 image in the provided compartment.</p>
@@ -1136,7 +1136,7 @@ The default is the latest OL8 image in the provided compartment.</p>
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>Cloud-init script to run during node startup.</p>
 </td>
@@ -1280,7 +1280,7 @@ NamespacedRef
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>Reference for cloud authentication.</p>
 </td>
@@ -1296,7 +1296,7 @@ PrivateRegistry
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>Private Registry settings for the workload cluster.</p>
 </td>
@@ -1312,7 +1312,7 @@ Proxy
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonClusterSpec">CommonClusterSpec</a>. Inlined comments are appended below.)
 </p>
 <p>HTTP Proxy settings.</p>
 </td>
@@ -1481,7 +1481,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>OCI region where the cluster will be created.</p>
 </td>
@@ -1495,7 +1495,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>OCI Compartment OCID where the cluster will be created</p>
 </td>
@@ -1509,7 +1509,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>SSH public key for node ssh.</p>
 </td>
@@ -1523,7 +1523,7 @@ string
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>Node image OCID.
 The default is the latest OL8 image in the provided compartment.</p>
@@ -1538,7 +1538,7 @@ The default is the latest OL8 image in the provided compartment.</p>
 </td>
 <td>
 <p>
-(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>.)
+(Inlined from <a href="#clusters.verrazzano.io/v1alpha1.CommonOCI">CommonOCI</a>. Inlined comments are appended below.)
 </p>
 <p>Cloud-init script to run during node startup.</p>
 </td>
@@ -2221,7 +2221,7 @@ int
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>89eacc2de</code>.
+on git commit <code>906e8361e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vpo-verrazzano-v1alpha1.md
+++ b/content/en/docs/reference/vpo-verrazzano-v1alpha1.md
@@ -284,10 +284,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -301,10 +306,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -348,10 +358,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -365,10 +380,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -412,10 +432,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -429,10 +454,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -478,7 +508,7 @@ uint32
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the number of pod instances to run.</p>
@@ -495,7 +525,7 @@ Kubernetes core/v1.Affinity
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the group of affinity scheduling rules.</p>
@@ -623,10 +653,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -640,10 +675,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -673,10 +713,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -690,10 +735,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -738,10 +788,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -755,10 +810,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -848,10 +908,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -865,10 +929,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -912,10 +980,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -929,10 +1002,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -991,10 +1069,11 @@ LetsEncryptACMEIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 <tr>
@@ -1008,10 +1087,11 @@ CAIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -1053,10 +1133,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1070,10 +1155,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1117,10 +1207,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1134,10 +1229,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2054,10 +2154,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2071,10 +2176,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2120,10 +2230,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2137,10 +2252,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2252,10 +2372,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/dex/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2269,10 +2394,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/dex/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2444,10 +2574,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2461,10 +2596,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2507,10 +2647,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2524,10 +2669,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2619,10 +2769,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2636,10 +2791,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2779,10 +2939,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2796,10 +2961,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3265,10 +3435,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3282,10 +3456,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3426,7 +3604,7 @@ uint32
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the number of pod instances to run.</p>
@@ -3443,7 +3621,7 @@ Kubernetes core/v1.Affinity
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the group of affinity scheduling rules.</p>
@@ -3488,10 +3666,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3505,10 +3688,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3552,10 +3740,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3569,10 +3762,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3644,10 +3842,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3661,10 +3864,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3763,10 +3971,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3780,10 +3993,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3857,10 +4075,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3874,10 +4097,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3952,10 +4180,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3969,10 +4202,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4016,10 +4254,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4033,10 +4276,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4426,10 +4674,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4443,10 +4696,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4522,10 +4780,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4539,10 +4802,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4586,10 +4854,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4603,10 +4876,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4650,10 +4928,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4667,10 +4950,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4734,10 +5022,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4751,10 +5044,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4798,10 +5096,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4815,10 +5118,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4920,10 +5228,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4937,10 +5250,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4984,10 +5302,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5001,10 +5324,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5062,10 +5390,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5079,10 +5412,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5616,10 +5954,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5633,10 +5976,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5675,7 +6023,7 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>89eacc2de</code>.
+on git commit <code>906e8361e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vpo-verrazzano-v1beta1.md
+++ b/content/en/docs/reference/vpo-verrazzano-v1beta1.md
@@ -284,10 +284,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -301,10 +306,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -348,10 +358,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -365,10 +380,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -412,10 +432,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -429,10 +454,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -559,10 +589,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -576,10 +611,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -624,10 +664,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -641,10 +686,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -734,10 +784,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -751,10 +805,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -798,10 +856,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -815,10 +878,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -877,10 +945,11 @@ LetsEncryptACMEIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The LetsEncrypt issuer configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The LetsEncrypt issuer configuration.</p>
 </td>
 </tr>
 <tr>
@@ -894,10 +963,11 @@ CAIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -939,10 +1009,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -956,10 +1031,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1003,10 +1083,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1020,10 +1105,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1899,10 +1989,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1916,10 +2011,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1965,10 +2065,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1982,10 +2087,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2055,10 +2165,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2072,10 +2187,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2187,10 +2307,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/dex/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2204,10 +2329,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/dex/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2280,10 +2410,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2297,10 +2432,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2343,10 +2483,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2360,10 +2505,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2425,10 +2575,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2442,10 +2597,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2615,10 +2775,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2632,10 +2797,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2993,10 +3163,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3010,10 +3184,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3057,10 +3235,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3074,10 +3257,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3121,10 +3309,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3138,10 +3331,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3199,10 +3397,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3216,10 +3419,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3263,10 +3471,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3280,10 +3493,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3357,10 +3575,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3374,10 +3597,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3438,10 +3666,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3455,10 +3688,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3502,10 +3740,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3519,10 +3762,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4052,10 +4300,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4069,10 +4322,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4148,10 +4406,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4165,10 +4428,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4212,10 +4480,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4229,10 +4502,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4276,10 +4554,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4293,10 +4576,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4360,10 +4648,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4377,10 +4670,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4424,10 +4722,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4441,10 +4744,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4546,10 +4854,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4563,10 +4876,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4610,10 +4928,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4627,10 +4950,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4674,10 +5002,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4691,10 +5024,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5228,10 +5566,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5245,10 +5588,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5287,7 +5635,7 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>89eacc2de</code>.
+on git commit <code>906e8361e</code>.
 </em></p>
 
 


### PR DESCRIPTION
API Install Overrides how include the links to the corresponding Helm chart.

![image](https://github.com/verrazzano/docs/assets/49332517/40579ef2-69da-4036-9528-8781d13e99b2)