### PR TITLE
VZ-11099 regenerate the API reference to include helm chart links

### DIFF
--- a/content/en/docs/reference/vao-clusters-v1alpha1.md
+++ b/content/en/docs/reference/vao-clusters-v1alpha1.md
@@ -1734,7 +1734,7 @@ ProjectTemplate
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>fd0b6edc0</code>.
+on git commit <code>3a421ac9e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vao-oam-v1alpha1.md
+++ b/content/en/docs/reference/vao-oam-v1alpha1.md
@@ -2126,7 +2126,7 @@ structs.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>fd0b6edc0</code>.
+on git commit <code>3a421ac9e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vco-clusters-v1alpha1.md
+++ b/content/en/docs/reference/vco-clusters-v1alpha1.md
@@ -616,7 +616,7 @@ StateType
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>fd0b6edc0</code>.
+on git commit <code>3a421ac9e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vpo-verrazzano-v1alpha1.md
+++ b/content/en/docs/reference/vpo-verrazzano-v1alpha1.md
@@ -284,10 +284,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -301,10 +306,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -348,10 +358,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -365,10 +380,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -412,10 +432,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -429,10 +454,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -478,7 +508,7 @@ uint32
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the number of pod instances to run.</p>
@@ -495,7 +525,7 @@ Kubernetes core/v1.Affinity
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the group of affinity scheduling rules.</p>
@@ -623,10 +653,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -640,10 +675,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -673,10 +713,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -690,10 +735,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -738,10 +788,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -755,10 +810,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -848,10 +908,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -865,10 +929,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -912,10 +980,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -929,10 +1002,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -991,10 +1069,11 @@ LetsEncryptACMEIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 <tr>
@@ -1008,10 +1087,11 @@ CAIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -1053,10 +1133,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1070,10 +1155,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1117,10 +1207,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1134,10 +1229,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2037,10 +2137,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2054,10 +2159,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2103,10 +2213,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2120,10 +2235,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2363,10 +2483,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2380,10 +2505,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2426,10 +2556,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2443,10 +2578,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2538,10 +2678,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2555,10 +2700,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2698,10 +2848,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2715,10 +2870,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3162,10 +3322,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3179,10 +3343,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3323,7 +3491,7 @@ uint32
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the number of pod instances to run.</p>
@@ -3340,7 +3508,7 @@ Kubernetes core/v1.Affinity
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.CommonKubernetesSpec">CommonKubernetesSpec</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
 <p>Specifies the group of affinity scheduling rules.</p>
@@ -3385,10 +3553,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3402,10 +3575,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3449,10 +3627,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3466,10 +3649,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3541,10 +3729,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3558,10 +3751,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3660,10 +3858,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3677,10 +3880,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3754,10 +3962,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3771,10 +3984,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3849,10 +4067,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3866,10 +4089,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3913,10 +4141,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3930,10 +4163,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4323,10 +4561,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4340,10 +4583,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4419,10 +4667,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4436,10 +4689,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4483,10 +4741,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4500,10 +4763,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4547,10 +4815,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4564,10 +4837,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4631,10 +4909,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4648,10 +4931,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4695,10 +4983,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4712,10 +5005,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4817,10 +5115,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4834,10 +5137,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4881,10 +5189,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4898,10 +5211,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4959,10 +5277,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4976,10 +5299,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5513,10 +5841,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5530,10 +5863,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1alpha1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5572,7 +5910,7 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>fd0b6edc0</code>.
+on git commit <code>3a421ac9e</code>.
 </em></p>
 
 

--- a/content/en/docs/reference/vpo-verrazzano-v1beta1.md
+++ b/content/en/docs/reference/vpo-verrazzano-v1beta1.md
@@ -284,10 +284,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -301,10 +306,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-application-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -348,10 +358,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -365,10 +380,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/argo-cd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -412,10 +432,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -429,10 +454,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -559,10 +589,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -576,10 +611,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/cert-manager/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -624,10 +664,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -641,10 +686,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -734,10 +784,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -751,10 +805,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>Overrides are merged together, but in the event of conflicting fields, the last override in the list
+takes precedence over any others. You can find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/overrides/cluster-api-values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -798,10 +856,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -815,10 +878,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -877,10 +945,11 @@ LetsEncryptACMEIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The LetsEncrypt issuer configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The LetsEncrypt issuer configuration.</p>
 </td>
 </tr>
 <tr>
@@ -894,10 +963,11 @@ CAIssuer
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.IssuerConfig">IssuerConfig</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>The certificate configuration.</p>
+<p>IssuerConfig contains the configuration for the Verrazzano Cert-Manager ClusterIssuer
+The certificate configuration.</p>
 </td>
 </tr>
 </tbody>
@@ -939,10 +1009,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -956,10 +1031,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1003,10 +1083,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1020,10 +1105,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/coherence-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1882,10 +1972,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1899,10 +1994,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-console/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -1948,10 +2048,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1965,10 +2070,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2038,10 +2148,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2055,10 +2170,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/external-dns/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2199,10 +2319,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2216,10 +2341,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2262,10 +2392,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2279,10 +2414,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2344,10 +2484,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2361,10 +2506,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2534,10 +2684,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2551,10 +2706,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/ingress-nginx/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2890,10 +3050,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2907,10 +3071,14 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for default IstioOperator. Overrides are merged together, but in the event of conflicting
+fields, the last override in the list takes precedence over any others. You can find all possible values
+<a href="https://istio.io/v1.13/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec">here</a>
+Passing through an invalid IstioOperator resource will result in an error.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -2954,10 +3122,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -2971,10 +3144,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/jaegertracing/jaeger-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3018,10 +3196,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3035,10 +3218,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/keycloak/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3096,10 +3284,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3113,10 +3306,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/kiali-server/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3160,10 +3358,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3177,10 +3380,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3254,10 +3462,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3271,10 +3484,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3335,10 +3553,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3352,10 +3575,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/mysql-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3399,10 +3627,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3416,10 +3649,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/oam-kubernetes-runtime/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -3949,10 +4187,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -3966,10 +4209,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-adapter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4045,10 +4293,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4062,10 +4315,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4109,10 +4367,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4126,10 +4389,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4173,10 +4441,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4190,10 +4463,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/prometheus-community/prometheus-pushgateway/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4257,10 +4535,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4274,10 +4557,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher-backup/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4321,10 +4609,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4338,10 +4631,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/rancher/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4443,10 +4741,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4460,10 +4763,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/thanos/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4507,10 +4815,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4524,10 +4837,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/velero/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -4571,10 +4889,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -4588,10 +4911,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/helm_config/charts/verrazzano/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5125,10 +5453,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+If false, then Verrazzano updates will ignore any configuration changes to this component. Defaults to <code>true</code>.</p>
 </td>
 </tr>
 <tr>
@@ -5142,10 +5475,15 @@ bool
 </td>
 <td>
 <p>
-(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>.)
+(Inlined from <a href="#install.verrazzano.io/v1beta1.InstallOverrides">InstallOverrides</a>. Inlined comments are appended below.)
 </p>
 <em>(Optional)</em>
-<p>List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
+<p>List of Overrides for the default <code>values.yaml</code> file for the component Helm chart. Overrides are merged together,
+but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
+find all possible values
+<a href="{{% release_source_url path=platform-operator/thirdparty/charts/weblogic-operator/values.yaml %}}">here</a>
+and invalid values will be ignored.
+List of overrides for the default values.yaml file for the component Helm chart. Overrides are merged together,
 but in the event of conflicting fields, the last override in the list takes precedence over any others.
 Invalid override values will be ignored.</p>
 </td>
@@ -5184,7 +5522,7 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>fd0b6edc0</code>.
+on git commit <code>3a421ac9e</code>.
 </em></p>
 
 


### PR DESCRIPTION
API Install Overrides how include the links to the corresponding Helm chart.

![image](https://github.com/verrazzano/docs/assets/49332517/40579ef2-69da-4036-9528-8781d13e99b2)
