### PR TITLE
Update Thanos version

### DIFF
--- a/content/en/docs/observability/monitoring/configure/thanos.md
+++ b/content/en/docs/observability/monitoring/configure/thanos.md
@@ -92,6 +92,9 @@ config:
 </div>
 {{< /clipboard >}}
 
+The OCI provider for Thanos object storage supports API signing keys, instance principal, and OKE workload identity authentication.
+For more information on configuring OCI Object Storage in Thanos, see [Oracle Cloud Infrastructure Object Storage](https://github.com/thanos-io/objstore#oracle-cloud-infrastructure-object-storage).
+
 ### Step 2: Create a secret
 
 Create the secret for object storage configuration using the `storage.yaml` file you created in Step 1.


### PR DESCRIPTION
Also add information on configuring the OCI Object Storage provider in Thanos. This is a backport of changes in #1454 to release-1.6.