### PR TITLE
Fix typo in Fluent Bit commands

### DIFF
--- a/content/en/docs/observability/logging/fluent-operator.md
+++ b/content/en/docs/observability/logging/fluent-operator.md
@@ -408,8 +408,8 @@ View the generated Fluent Bit configuration that the Fluent Operator loads in a 
 <div class="highlight">
 
 ```
-$ kubectl -n verrazzano-system get secrets Fluent Bit-config -ojson | jq '.data."fluent-bit.conf"' | awk -F '"' '{printf $2}' | base64 --decode
-$ kubectl -n verrazzano-system get secrets Fluent Bit-config -ojson | jq '.data."parsers.conf"' | awk -F '"' '{printf $2}' | base64 --decode
+$ kubectl -n verrazzano-system get secrets fluent-bit-config -ojson | jq '.data."fluent-bit.conf"' | awk -F '"' '{printf $2}' | base64 --decode
+$ kubectl -n verrazzano-system get secrets fluent-bit-config -ojson | jq '.data."parsers.conf"' | awk -F '"' '{printf $2}' | base64 --decode
 ```
 </div>
 {{< /clipboard >}}


### PR DESCRIPTION
Looks like this was a global search and replace issue. Fix the example Fluent Bit commands to use the correct secret name.