### PR TITLE
Add cert manager integration placeholders back in and remove fluentd references

### DIFF
--- a/content/en/docs/guides/migrate/integrate/cert-manager/_index.md
+++ b/content/en/docs/guides/migrate/integrate/cert-manager/_index.md
@@ -43,3 +43,7 @@ EOF
 {{< /clipboard >}}
 
 This will restrict ingress to be allowed only to pods in the `cert-manager` namespace with the `app: cert-manager` label on TCP port 9402 from Prometheus pods the `monitoring`  namespace.
+
+## Fluent Bit
+## Network Policies
+## Prometheus

--- a/content/en/docs/guides/migrate/integrate/istio/_index.md
+++ b/content/en/docs/guides/migrate/integrate/istio/_index.md
@@ -5,6 +5,6 @@ draft: false
 ---
 This document shows you how to integrate Istio with other OCNE components.
 
-## Fluentd and Fluent Bit
+## Fluent Bit
 ## Network Policies
 ## Prometheus

--- a/content/en/docs/guides/migrate/integrate/nginx/_index.md
+++ b/content/en/docs/guides/migrate/integrate/nginx/_index.md
@@ -5,6 +5,6 @@ draft: false
 ---
 This document shows you how to integrate Ingress NGINX Controller with other OCNE components.
 
-## Fluentd and Fluent Bit
+## Fluent Bit
 ## Network Policies
 ## Prometheus

--- a/content/en/docs/guides/migrate/integrate/prometheus/_index.md
+++ b/content/en/docs/guides/migrate/integrate/prometheus/_index.md
@@ -5,7 +5,7 @@ draft: false
 ---
 This document shows you how to integrate Prometheus with other OCNE components.
 
-## Fluentd and Fluent Bit
+## Fluent Bit
 ## Ingress
 ## Istio
 ## Network Policies


### PR DESCRIPTION
This change adds the placeholders back into the cert manager integration doc. It also removes references to fluentd from all the integration docs.