### PR TITLE
VZ-11732: Update to WKO Migration Pages

### DIFF
--- a/content/en/docs/guides/migrate/install/weblogic/_index.md
+++ b/content/en/docs/guides/migrate/install/weblogic/_index.md
@@ -154,48 +154,6 @@ EOF
 </div>
 {{< /clipboard >}}
 
-In addition, the following Network Policy must be created in the `weblogic-operator` namespace. This Network Policy for a WebLogic Kubernetes Operator pod allows the following:
-
-- Allows ingress traffic to any port from the `istio-system` namespace
-- Allows ingress traffic to envoy port 15090 from the Prometheus pod in the `verrazzano-monitoring` namespace
-- Egress traffic is not restricted
-
-{{< clipboard >}}
-<div class="highlight">
-
-```
-kubectl apply -n weblogic-operator -f - <<EOF
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: weblogic-operator
-  namespace: weblogic-operator
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: istio-system
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: monitoring
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/name: prometheus
-    ports:
-    - port: 15090
-      protocol: TCP
-  podSelector:
-    matchLabels:
-       app: weblogic-operator
-  policyTypes:
-  - Ingress
-EOF
-```
-</div>
-{{< /clipboard >}}
-
 ## Migrate OAM WebLogic applications to OCNE 2.0
 As part of the migration, each OAM WebLogic application needs to be moved from the Verrazzano environment to the OCNE 2.0 environment. You will need to redeploy each OAM application in OCNE 2.0 without using OAM. This process is described in [OAM to Kubernetes Mappings]({{< relref "/docs/guides/migrate/oam-to-kubernetes/_index.md" >}}).
 

--- a/content/en/docs/guides/migrate/integrate/weblogic/_index.md
+++ b/content/en/docs/guides/migrate/integrate/weblogic/_index.md
@@ -5,6 +5,49 @@ draft: false
 ---
 This document shows you how to integrate WebLogic Kubernetes Operator with other OCNE components.
 
-## Fluentd and Fluent Bit
+## Fluent Bit
+
 ## Network Policies
+The following Network Policy must be created in the `weblogic-operator` namespace. This Network Policy for a WebLogic Kubernetes Operator pod allows the following:
+
+- Allows ingress traffic to any port from the `istio-system` namespace
+- Allows ingress traffic to envoy port 15090 from the Prometheus pod in the `verrazzano-monitoring` namespace
+- Egress traffic is not restricted
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+kubectl apply -n weblogic-operator -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: weblogic-operator
+  namespace: weblogic-operator
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: istio-system
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 15090
+      protocol: TCP
+  podSelector:
+    matchLabels:
+       app: weblogic-operator
+  policyTypes:
+  - Ingress
+EOF
+```
+</div>
+{{< /clipboard >}}
+
 ## Prometheus


### PR DESCRIPTION
This PR updates the WebLogic Operator migration pages.

- Moves the NetworkPolicy section from the install page to the integrate page
- Removes "Fluentd" from a heading in the integrate page