### PR TITLE
VZ-11732: WKO migration docs - move Migrate OAM section

### DIFF
--- a/content/en/docs/guides/migrate/install/weblogic/_index.md
+++ b/content/en/docs/guides/migrate/install/weblogic/_index.md
@@ -153,19 +153,3 @@ EOF
 ```
 </div>
 {{< /clipboard >}}
-
-## Migrate OAM WebLogic applications to OCNE 2.0
-As part of the migration, each OAM WebLogic application needs to be moved from the Verrazzano environment to the OCNE 2.0 environment. You will need to redeploy each OAM application in OCNE 2.0 without using OAM. This process is described in [OAM to Kubernetes Mappings]({{< relref "/docs/guides/migrate/oam-to-kubernetes/_index.md" >}}).
-
-For each OAM application, start with the following command in your Verrazzano environment.
-
-{{< clipboard >}}
-<div class="highlight">
-
-```
-$ vz export oam --name <app-name> --namespace <app-namespace> > myapp.yaml
-```
-</div>
-{{< /clipboard >}}
-
-This generates a YAML file for the OAM application in `myapp.yaml`. Make any local customizations to the generated YAML file, and then apply the YAML file to the OCNE 2.0 environment by continuing to follow the documentation.

--- a/content/en/docs/guides/migrate/integrate/weblogic/_index.md
+++ b/content/en/docs/guides/migrate/integrate/weblogic/_index.md
@@ -51,3 +51,19 @@ EOF
 {{< /clipboard >}}
 
 ## Prometheus
+
+## Migrate OAM WebLogic applications to OCNE 2.0
+As part of the migration, each OAM WebLogic application needs to be moved from the Verrazzano environment to the OCNE 2.0 environment. You will need to redeploy each OAM application in OCNE 2.0 without using OAM. This process is described in [OAM to Kubernetes Mappings]({{< relref "/docs/guides/migrate/oam-to-kubernetes/_index.md" >}}).
+
+For each OAM application, start with the following command in your Verrazzano environment.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ vz export oam --name <app-name> --namespace <app-namespace> > myapp.yaml
+```
+</div>
+{{< /clipboard >}}
+
+This generates a YAML file for the OAM application in `myapp.yaml`. Make any local customizations to the generated YAML file, and then apply the YAML file to the OCNE 2.0 environment by continuing to follow the documentation.


### PR DESCRIPTION
In the WebLogic Kubernetes Operator migration docs, moves the "Migrate OAM WebLogic applications to OCNE 2.0" section from the install page to the integrate page.