### PR TITLE
Add Istio information to the Prometheus integration page

### DIFF
--- a/content/en/docs/guides/migrate/integrate/istio/_index.md
+++ b/content/en/docs/guides/migrate/integrate/istio/_index.md
@@ -8,3 +8,80 @@ This document shows you how to integrate Istio with other OCNE components.
 ## Fluent Bit
 ## Network Policies
 ## Prometheus
+
+Prometheus can scrape metrics from Istio Pilot and Envoy sidecars in the cluster. Apply the following Prometheus ServiceMonitor and PodMonitor resources to collect Istio metrics in all namespaces.
+This example assumes that Istio has been installed in the `istio-system` namespace and Prometheus has been installed in the `monitoring` namespace.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: prometheus-operator
+  name: pilot
+  namespace: monitoring
+spec:
+  endpoints:
+  - enableHttp2: false
+    relabelings:
+    - action: keep
+      regex: istiod;http-monitoring
+      sourceLabels:
+      - __meta_kubernetes_service_name
+      - __meta_kubernetes_endpoint_port_name
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_service_label_app
+      targetLabel: app
+  namespaceSelector:
+    matchNames:
+    - istio-system
+  selector: {}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    release: prometheus-operator
+  name: envoy-stats
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - enableHttp2: false
+    path: /stats/prometheus
+    relabelings:
+    - action: keep
+      regex: .*-envoy-prom
+      sourceLabels:
+      - __meta_kubernetes_pod_container_port_name
+    - action: drop
+      regex: Succeeded
+      sourceLabels:
+      - __meta_kubernetes_pod_phase
+    - action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:15090
+      sourceLabels:
+      - __address__
+      - __meta_kubernetes_pod_annotation_prometheus_io_port
+      targetLabel: __address__
+    - action: labeldrop
+      regex: __meta_kubernetes_pod_label_(.+)
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_name
+      targetLabel: pod_name
+  selector: {}
+```
+</div>
+{{< /clipboard >}}

--- a/content/en/docs/guides/migrate/integrate/prometheus/_index.md
+++ b/content/en/docs/guides/migrate/integrate/prometheus/_index.md
@@ -8,6 +8,92 @@ This document shows you how to integrate Prometheus with other OCNE components.
 ## Fluent Bit
 ## Ingress
 ## Istio
+
+The Istio Authorization Policy custom resource enables access control on workloads in the mesh.
+
+Apply the following custom resource to allow the authenticating proxy to forward network traffic to the Prometheus web UI. This example assumes the `kube-prometheus-stack` Helm release name is `prometheus-operator`.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: prometheus-authzpol
+  namespace: monitoring
+spec:
+  rules:
+  - from:
+    - source:
+        namespaces:
+        - TBD FILL THIS IN WITH THE NAMESPACE OF THE AUTHENTICATING PROXY
+        principals:
+        - cluster.local/ns/TBD FILL THIS IN WITH THE SERVICE ACCOUNT OF THE AUTHENTICATING PROXY
+    to:
+    - operation:
+        ports:
+        - "9090"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+EOF
+```
+</div>
+{{< /clipboard >}}
+
+Prometheus can scrape metrics from Istio Envoy sidecars in the cluster. Apply the following Prometheus PodMonitor resource to collect Envoy metrics in all namespaces.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    release: prometheus-operator
+  name: envoy-stats
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - enableHttp2: false
+    path: /stats/prometheus
+    relabelings:
+    - action: keep
+      regex: .*-envoy-prom
+      sourceLabels:
+      - __meta_kubernetes_pod_container_port_name
+    - action: drop
+      regex: Succeeded
+      sourceLabels:
+      - __meta_kubernetes_pod_phase
+    - action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:15090
+      sourceLabels:
+      - __address__
+      - __meta_kubernetes_pod_annotation_prometheus_io_port
+      targetLabel: __address__
+    - action: labeldrop
+      regex: __meta_kubernetes_pod_label_(.+)
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_name
+      targetLabel: pod_name
+  selector: {}
+```
+</div>
+{{< /clipboard >}}
+
 ## Network policies
 NetworkPolicies let you specify how a pod is allowed to communicate with various network entities in a cluster. NetworkPolicies increase the security posture of the cluster by limiting network traffic and preventing unwanted network communication. NetworkPolicy resources affect layer 4 connections (TCP, UDP, and optionally SCTP). The cluster must be running a Container Network Interface (CNI) plug-in that enforces NetworkPolicies.
 

--- a/content/en/docs/guides/migrate/integrate/prometheus/_index.md
+++ b/content/en/docs/guides/migrate/integrate/prometheus/_index.md
@@ -11,8 +11,7 @@ This document shows you how to integrate Prometheus with other OCNE components.
 
 The Istio Authorization Policy custom resource enables access control on workloads in the mesh.
 
-Apply the following custom resource to allow the authenticating proxy to forward network traffic to the Prometheus web UI. This example assumes the `kube-prometheus-stack` Helm release name is `prometheus-operator`.
-
+Apply the following custom resource to allow the authenticating proxy to forward network traffic to the Prometheus web UI. This example assumes Prometheus is installed in the `monitoring` namespace.
 {{< clipboard >}}
 <div class="highlight">
 
@@ -39,57 +38,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: prometheus
 EOF
-```
-</div>
-{{< /clipboard >}}
-
-Prometheus can scrape metrics from Istio Envoy sidecars in the cluster. Apply the following Prometheus PodMonitor resource to collect Envoy metrics in all namespaces.
-
-{{< clipboard >}}
-<div class="highlight">
-
-```
-$ kubectl apply -f - <<EOF
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  labels:
-    release: prometheus-operator
-  name: envoy-stats
-  namespace: monitoring
-spec:
-  namespaceSelector:
-    any: true
-  podMetricsEndpoints:
-  - enableHttp2: false
-    path: /stats/prometheus
-    relabelings:
-    - action: keep
-      regex: .*-envoy-prom
-      sourceLabels:
-      - __meta_kubernetes_pod_container_port_name
-    - action: drop
-      regex: Succeeded
-      sourceLabels:
-      - __meta_kubernetes_pod_phase
-    - action: replace
-      regex: ([^:]+)(?::\d+)?;(\d+)
-      replacement: $1:15090
-      sourceLabels:
-      - __address__
-      - __meta_kubernetes_pod_annotation_prometheus_io_port
-      targetLabel: __address__
-    - action: labeldrop
-      regex: __meta_kubernetes_pod_label_(.+)
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_namespace
-      targetLabel: namespace
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_name
-      targetLabel: pod_name
-  selector: {}
 ```
 </div>
 {{< /clipboard >}}


### PR DESCRIPTION
Adds the following Istio information to the Prometheus integration page of the OCNE 2.0 migration documentation:

1. An AuthorizationPolicy to allow the authenticating proxy to forward traffic to the Prometheus UI
2. A Prometheus PodMonitor to scrape Istio Envoy sidecar metrics

Note that since we don't yet have a solution for the authenticating proxy, there is placeholder information in the AuthorizationPolicy that will need to be filled in later.