### PR TITLE
Updates for Prometheus integration pages

### DIFF
--- a/content/en/docs/guides/migrate/integrate/cert-manager/_index.md
+++ b/content/en/docs/guides/migrate/integrate/cert-manager/_index.md
@@ -46,4 +46,3 @@ This will restrict ingress to be allowed only to pods in the `cert-manager` name
 
 ## Fluent Bit
 ## Network Policies
-## Prometheus

--- a/content/en/docs/guides/migrate/integrate/opensearch/_index.md
+++ b/content/en/docs/guides/migrate/integrate/opensearch/_index.md
@@ -9,3 +9,54 @@ This document shows you how to integrate OpenSearch with other OCNE components.
 ## Ingress
 ## Istio
 ## Prometheus
+
+Apply the following `ServiceMonitor` resource to scrape metrics from OpenSearch pods. This assumes Prometheus Operator has been installed in the `monitoring` namespace and OpenSearch has been installed in the `logging` namespace.
+
+{{< clipboard >}}
+<div class="highlight">
+
+```
+$ kubectl apply -f - <<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: prometheus-operator
+  name: opensearch
+  namespace: monitoring
+spec:
+  endpoints:
+  - enableHttp2: false
+    path: /_prometheus/metrics
+    relabelings:
+    - action: keep
+      regex: opensearch-cluster-.*
+      sourceLabels:
+      - __meta_kubernetes_pod_name
+    - action: keep
+      regex: "9200"
+      sourceLabels:
+      - __meta_kubernetes_pod_container_port_number
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_name
+      targetLabel: kubernetes_pod_name
+    scheme: https
+    tlsConfig:
+      caFile: /etc/istio-certs/root-cert.pem
+      certFile: /etc/istio-certs/cert-chain.pem
+      insecureSkipVerify: true
+      keyFile: /etc/istio-certs/key.pem
+  namespaceSelector:
+    matchNames:
+    - logging
+  selector: {}
+```
+</div>
+{{< /clipboard >}}
+
+This `ServiceMonitor` assumes OpenSearch is running in the Istio mesh. If OpenSearch is not in the Istio mesh, then remove the `tlsConfig` and change the `scheme` to `http`.

--- a/content/en/docs/guides/migrate/integrate/weblogic/_index.md
+++ b/content/en/docs/guides/migrate/integrate/weblogic/_index.md
@@ -50,8 +50,6 @@ EOF
 </div>
 {{< /clipboard >}}
 
-## Prometheus
-
 ## Migrate OAM WebLogic applications to OCNE 2.0
 As part of the migration, each OAM WebLogic application needs to be moved from the Verrazzano environment to the OCNE 2.0 environment. You will need to redeploy each OAM application in OCNE 2.0 without using OAM. This process is described in [OAM to Kubernetes Mappings]({{< relref "/docs/guides/migrate/oam-to-kubernetes/_index.md" >}}).
 


### PR DESCRIPTION
This PR adds the Prometheus integration information to the OpenSearch integration page.

Notes:

1. Verrazzano does not collect metrics for cert-manager and the WebLogic Kubernetes Operator, so I have removed the Prometheus titles from those integration pages
2. The Prometheus information for the Istio integration page is being added in PR #1582 