### PR TITLE
VZ-11751: Istio Network Policies Migration - load dump

### DIFF
--- a/content/en/docs/guides/migrate/integrate/istio/_index.md
+++ b/content/en/docs/guides/migrate/integrate/istio/_index.md
@@ -139,9 +139,6 @@ spec:
           - fluent-bit
     - podSelector:
         matchLabels:
-          job-name: load-dump
-    - podSelector:
-        matchLabels:
           app.kubernetes.io/name: ingress-nginx
     - podSelector:
         matchLabels:


### PR DESCRIPTION
Removes load-dump from a network policy, since it is related to mysql.
The verrazzano repo has references to load-dump, all in relation to mysql.